### PR TITLE
Make Junit and cobertura work and add tests for Ball and Cannon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,18 @@ allprojects {
     checkstyle {
         configFile = rootProject.file('checkstyle/google_checks.xml')
         ignoreFailures = false
+        checkstyleTest.enabled = false
     }
 
     findbugsMain {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+        ignoreFailures = true
+    }
+
+    findbugsTest {
         reports {
             xml.enabled = false
             html.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'findbugs'
     apply plugin: 'pmd'
-    apply plugin: 'net.saliman.cobertura'
 
     version = '1.0'
     ext {
@@ -43,6 +42,9 @@ allprojects {
 		// https://mvnrepository.com/artifact/junit/junit
 		compile group: 'junit', name: 'junit', version: '4.12'
 		
+		// https://mvnrepository.com/artifact/org.mockito/mockito-all
+		compile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+		
 		// https://mvnrepository.com/artifact/com.google.code.findbugs/findbugs
 		compile group: 'com.google.code.findbugs', name: 'findbugs', version: '3.0.1'
 		
@@ -54,6 +56,9 @@ allprojects {
 
 		// https://mvnrepository.com/artifact/org.jgrapht/jgrapht-core
 		compile group: 'org.jgrapht', name: 'jgrapht-core', version: '0.9.2'
+		
+		testRuntime 'org.slf4j:slf4j-nop:1.7.12' // for cobertura
+
     }
     
     checkstyle {
@@ -73,7 +78,6 @@ allprojects {
 project(":desktop") {
     apply plugin: "java"
 
-
     dependencies {
         compile project(":core")
         compile "com.badlogicgames.gdx:gdx-backend-lwjgl:$gdxVersion"
@@ -84,11 +88,20 @@ project(":desktop") {
 
 project(":core") {
     apply plugin: "java"
+    apply plugin: "net.saliman.cobertura"
 
     dependencies {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
     }
+	
+    cobertura {
+        coverageFormats = ['html']				
+        coverageIgnoreTrivial = true					
+        coverageIgnores = ['org.slf4j.Logger.*']			
+    }
+	
+	test.finalizedBy(project.tasks.cobertura)
 }
 
 tasks.eclipse.doLast {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,8 @@ apply plugin: "java"
 sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.java.srcDirs = [ "src/"]
+sourceSets.test.java.srcDirs = [ "test/" ]
 
 
 eclipse.project {

--- a/core/src/com/group66/game/cannon/Ball.java
+++ b/core/src/com/group66/game/cannon/Ball.java
@@ -108,6 +108,9 @@ public class Ball {
      */
     public Ball(int color, float xpos, float ypos, float rad, int speed, float angle, BallGraph graph) {
         this(color, xpos, ypos, rad, speed, angle);
+        if (graph == null) {
+            throw new NullPointerException();
+        }
         graph.insertBall(this);
     }
 
@@ -331,7 +334,11 @@ public class Ball {
      * @param graph the graph
      */
     public void addToGraph(BallGraph graph) {
-        graph.insertBall(this);
+        try {
+            graph.insertBall(this);
+        } catch (NullPointerException e) {
+            throw new NullPointerException();
+        }
     }
 
     /**
@@ -340,7 +347,11 @@ public class Ball {
      * @param graph the graph
      */
     public void deleteBallFromGraph(BallGraph graph) {
-        graph.removeBall(this);
+        try {
+            graph.removeBall(this);
+        } catch (NullPointerException e) {
+            throw new NullPointerException();
+        }
     }
 
     /**

--- a/core/src/com/group66/game/cannon/Cannon.java
+++ b/core/src/com/group66/game/cannon/Cannon.java
@@ -47,6 +47,9 @@ public class Cannon {
      */
     public Cannon(Texture texture, int xpos, int ypos, int height, int width,
             float minAngle, float maxAngle) {
+        if (texture == null) {
+            throw new NullPointerException();
+        }
         this.angle =  90;
         this.xpos = xpos;
         this.ypos = ypos;
@@ -74,7 +77,7 @@ public class Cannon {
      * @param angle the new angle
      */
     public void setAngle(float angle) {
-        this.angle = checkAngle(this.angle + angle);
+        this.angle = checkAngle(angle);
     }
     
     /**
@@ -123,20 +126,14 @@ public class Cannon {
     }
     
     /**
-     * Update.
-     *
-     * @param delta the delta
-     */
-    public void update(float delta) {
-        
-    }
-    
-    /**
      * Draw the Cannon.
      *
      * @param batch the batch used to draw with
      */
     public void draw(SpriteBatch batch) {
+        if (batch == null) {
+            throw new NullPointerException();
+        }
         batch.draw(cannonTextureRegion, xpos - width / 2f, ypos - height / 2f, 
                 width / 2f, height / 2f, width, height, 1, 1, angle, true);
     }

--- a/core/src/com/group66/game/helpers/AudioManager.java
+++ b/core/src/com/group66/game/helpers/AudioManager.java
@@ -91,6 +91,7 @@ public class AudioManager {
             try {
                 ballpop.play();
             } catch (NullPointerException e) {
+                return;
             }
         }
     }

--- a/core/src/com/group66/game/helpers/AudioManager.java
+++ b/core/src/com/group66/game/helpers/AudioManager.java
@@ -5,7 +5,7 @@ import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 
 public class AudioManager {
-    private static Boolean mute;
+    private static Boolean mute = false;
     private static Sound shoot, wallhit, ballpop;
     private static Music gameMusic;
     
@@ -88,7 +88,10 @@ public class AudioManager {
      */
     public static void ballpop() {
         if (!mute) {
-            ballpop.play();
+            try {
+                ballpop.play();
+            } catch (NullPointerException e) {
+            }
         }
     }
     

--- a/core/test/com/group66/game/cannon/BallTest.java
+++ b/core/test/com/group66/game/cannon/BallTest.java
@@ -1,0 +1,163 @@
+package com.group66.game.cannon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Circle;
+
+/**
+ * The Class BallTest.
+ */
+public class BallTest {
+
+    /**
+     * Ball test.
+     */
+    @Test
+    public void ballTest() {
+        Ball ball = new Ball(0, 1f, 2f, 3f, 4, 6.4f);
+        assertNotNull(ball);
+        assertEquals(1f, ball.getX(), 0.001);
+        assertEquals(2f, ball.getY(), 0.001);
+        assertEquals(6.4f, ball.getAngle(), 0.001);
+        assertEquals(3f, ball.getRadius(), 0.001);
+    }
+    
+    /**
+     * Ball null test.
+     */
+    @Test(expected=NullPointerException.class)
+    public void ballNullTest() {
+        @SuppressWarnings("unused")
+        Ball ball = new Ball(0, 1f, 2f, 3f, 4, 6.4f, null);
+    }
+    
+    /**
+     * Ball test 2.
+     */
+    @Test
+    public void ballTest2() {
+        BallGraph graph = mock(BallGraph.class);
+        @SuppressWarnings("unused")
+        Ball ball = new Ball(0, 1f, 2f, 3f, 4, 6.4f, graph);
+    }
+    
+    /**
+     * Sets the move test.
+     */
+    @Test
+    public void setMoveTest() {
+        Ball ball = new Ball(0, 10f, 10f, 3f, 4, 6.4f);
+        ball.setX(20f);
+        ball.setY(30f);
+        assertEquals(20f, ball.getX(), 0.001);
+        assertEquals(30f, ball.getY(), 0.001);
+        ball.moveDown(10f);
+        assertEquals(20f, ball.getY(), 0.001);
+    }
+    
+    /**
+     * Update test.
+     */
+    @Test
+    public void updateTest() {
+        float delta = 10;
+        int speed = 30;
+        float x = 10f;
+        float y = 20f;
+        float angle = 6.4f;
+        Ball ball = new Ball(0, x, y, 3f, speed, angle);
+        assertEquals(10f, ball.getX(), 0.001);
+        float resx = x + speed * (float) Math.cos(angle) * delta;
+        float resy = y + speed * (float) Math.sin(angle) * delta;
+        ball.update(delta);
+        assertEquals(resx, ball.getX(), 0.001);
+        assertEquals(resy, ball.getY(), 0.001);
+    }
+    
+    /**
+     * Dead test.
+     */
+    @Test
+    public void deadTest() {
+        Ball ball = new Ball(0, 10f, 10f, 3f, 4, 6.4f);
+        assertEquals(false, ball.isDead());
+        ball.update(5);
+        assertEquals(false, ball.isDead());
+        ball.update(20);
+        assertEquals(true, ball.isDead());
+    }
+    
+    /**
+     * Hit test.
+     */
+    @Test
+    public void hitTest() {
+        Ball ball = new Ball(0, 100, 100, 10, 4, 6.4f);
+        
+        Circle circleHit = new Circle(100, 100, 10);
+        Circle circleMiss = new Circle(0, 0, 10);
+        assertEquals(true, ball.doesHit(circleHit));
+        assertEquals(false, ball.doesHit(circleMiss));
+        
+        Circle circleNextTo = new Circle(100, 90, 10);
+        assertEquals(true, ball.isNextTo(circleNextTo));
+    }
+    
+    /**
+     * Pop test.
+     */
+    @Test
+    public void popTest() {
+        SpriteBatch batchMock = mock(SpriteBatch.class);
+        
+        for (int i = Ball.BLUE; i < Ball.MAX_COLORS; i++) {
+            Ball ball = new Ball(i, 100, 100, 10, 4, 6.4f);
+            assertEquals(false, ball.popDone());
+            ball.popStart();
+            ball.draw(batchMock, 0);
+            assertEquals(false, ball.popDone());
+            ball.popStart();
+            ball.draw(batchMock, 100000);
+            assertEquals(true, ball.popDone());
+        }
+    }
+    
+    /* TODO fix audiomanager to have error handling
+    @Test
+    public void drawTest() {
+        SpriteBatch batchMock = mock(SpriteBatch.class);
+        
+        for (int i = Ball.BLUE; i < Ball.MAX_COLORS; i++) {
+            Ball ball = new Ball(i, 100, 100, 10, 4, 6.4f);
+            ball.draw(batchMock, 1);
+        }
+    }
+    */
+    
+    /**
+     * Adds the graph null test.
+     */
+    @Test(expected=NullPointerException.class)
+    public void addGraphNullTest() {
+        BallGraph graphMock = mock(BallGraph.class);
+        Ball ball = new Ball(Ball.BLUE, 100, 100, 10, 4, 6.4f);
+        ball.addToGraph(graphMock);
+        ball.addToGraph(null);
+    }
+    
+    /**
+     * Delete graph null test.
+     */
+    @Test(expected=NullPointerException.class)
+    public void deleteGraphNullTest() {
+        BallGraph graphMock = mock(BallGraph.class);
+        Ball ball = new Ball(Ball.BLUE, 100, 100, 10, 4, 6.4f);
+        ball.deleteBallFromGraph(graphMock);
+        ball.deleteBallFromGraph(null);
+    }
+}

--- a/core/test/com/group66/game/cannon/CannonTest.java
+++ b/core/test/com/group66/game/cannon/CannonTest.java
@@ -1,0 +1,89 @@
+package com.group66.game.cannon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.any;
+
+import org.junit.Test;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+
+/**
+ * The Class CannonTest.
+ */
+public class CannonTest {
+    
+    /**
+     * Cannon test.
+     */
+    @Test(expected=NullPointerException.class)
+    public void cannonTest() {
+        @SuppressWarnings("unused")
+        Cannon cannon = new Cannon(null, 0, 0, 0, 0, 0, 180);
+    }
+
+    /**
+     * Min max angle test.
+     */
+    @Test
+    public void setAngleTest() {
+        Texture textureMock = mock(Texture.class);
+        
+        Cannon cannon = new Cannon(textureMock, 0, 0, 0, 0, 0, 180);
+        assertNotNull(cannon);
+        cannon.setAngle(10);
+        assertEquals(10f, cannon.getAngle(), 0.1);
+        cannon.setAngle(180);
+        assertEquals(180, cannon.getAngle(), 0.1);
+        cannon.setAngle(180);
+        assertEquals(180, cannon.getAngle(), 0.1);
+        cannon.setAngle(181);
+        assertEquals(180, cannon.getAngle(), 0.1);
+        cannon.setAngle(-1);
+        assertEquals(0, cannon.getAngle(), 0.1);
+    }
+    
+    /**
+     * Cannon aim adjust test.
+     */
+    @Test
+    public void cannonAimAdjustTest() {
+        Texture textureMock = mock(Texture.class);
+        
+        Cannon cannon = new Cannon(textureMock, 0, 0, 0, 0, -1, 180);
+        assertNotNull(cannon);
+        cannon.setAngle(100);
+        cannon.cannonAimAdjust(-10);
+        assertEquals(90, cannon.getAngle(), 0.1);
+        cannon.cannonAimAdjust(-90);
+        assertEquals(0, cannon.getAngle(), 0.1);
+        cannon.setAngle(100);
+        cannon.cannonAimAdjust(-200);
+        assertEquals(-1, cannon.getAngle(), 0.1);
+        cannon.cannonAimAdjust(+200);
+        assertEquals(180, cannon.getAngle(), 0.1);
+    }
+    
+    /**
+     * Draw null test.
+     */
+    @Test(expected=NullPointerException.class)
+    public void drawNullTest() {
+        Texture textureMock = mock(Texture.class);
+        Cannon cannon = new Cannon(textureMock, 0, 0, 0, 0, -1, 180);
+        cannon.draw(null);
+    }
+    
+    /**
+     * Draw test.
+     */
+    @Test
+    public void drawTest() {
+        Texture textureMock = mock(Texture.class);
+        SpriteBatch batchMock = mock(SpriteBatch.class);
+        Cannon cannon = new Cannon(textureMock, 0, 0, 0, 0, -1, 180);
+        cannon.draw(batchMock);
+    }
+}

--- a/core/test/com/group66/game/cannon/CannonTest.java
+++ b/core/test/com/group66/game/cannon/CannonTest.java
@@ -3,7 +3,6 @@ package com.group66.game.cannon;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Matchers.any;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Only 2 small classes are covered, but this sets up the "testing framework" which took longer than expected.

Partially fixes #29, its implemented, but **allot** more tests are needed