### PR TITLE
Remove object update from the draw

### DIFF
--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -322,10 +322,6 @@ public class BallManager {
      * @param delta the delta
      */
     public void draw(SpriteBatch batch, float delta) {
-
-        /* Update the ball lists and graph */
-        updateBalls(delta);
-
         int xoffset = Config.SINGLE_PLAYER_OFFSET;
         if (isSplit) {
             xoffset = Config.SEGMENT_OFFSET * segmentOffset;
@@ -525,7 +521,7 @@ public class BallManager {
      *
      * @param delta the delta
      */
-    private void updateBalls(float delta) {
+    public void update(float delta) {
         /* Start counting time*/
         timeKeeper.universalTimeCounter(delta);
         

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -70,9 +70,15 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
             BustaMove.getGameInstance().batch.begin();
             BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
+            
+            /* Update the balls without letting them move*/
+            ballManager.update(0);
             return;
         }
-
+        
+        /* Update the balls */
+        ballManager.update(delta);
+        
         Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -78,8 +78,18 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
             BustaMove.getGameInstance().batch.begin();
             BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
+            
+            /* Update the balls without letting them move*/
+            ballManager1.update(0);
+            ballManager2.update(0);
+            ballManager2.update(0);
             return;
         }
+        
+        /* Update the balls */
+        ballManager1.update(delta);
+        ballManager2.update(delta);
+        ballManager3.update(delta);
 
         Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -74,8 +74,16 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
             BustaMove.getGameInstance().batch.begin();
             BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
+            
+            /* Update the balls without letting them move*/
+            ballManager1.update(0);
+            ballManager2.update(0);
             return;
         }
+        
+        /* Update the balls */
+        ballManager1.update(delta);
+        ballManager2.update(delta);
 
         Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
The idea was already there, the only change needed was to make the
update function in the BallManager public and call it in the game
screen. Now the current screen can still be drawn without updating
locations and other stuff.

Fixes #53 