### PR TITLE
Enhancement/asset loader split

### DIFF
--- a/core/src/com/group66/game/cannon/BallAnimationLoader.java
+++ b/core/src/com/group66/game/cannon/BallAnimationLoader.java
@@ -1,33 +1,16 @@
-package com.group66.game.helpers;
+package com.group66.game.cannon;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.group66.game.helpers.ProfileManager;
 
 /**
  * A AssetLoader for sprite textures.
  */
-public class AssetLoader {
-
-    /** YouWin Screen background texture. */
-    private static Texture youwinbgTexture;
-
-    /** YouWin Screen background texture region. */
-    public static TextureRegion youwinbg;
-
-    /** YouLose Screen background texture. */
-    private static Texture youlosebgTexture;
-
-    /** YouLose Screen background texture region. */
-    public static TextureRegion youlosebg;
-
-    /** YouWin Screen background texture. */
-    private static Texture youwinAllbgTexture;
-
-    /** YouWin Screen background texture region. */
-    public static TextureRegion youwinAllbg;
+public class BallAnimationLoader {
 
     /** The ball texture. */
     private static Texture ballTexture;
@@ -70,23 +53,7 @@ public class AssetLoader {
         /**
          * MainMenu, YouWin, and YouLose screens Sprites
          */
-
-        //Creating the YouWin screen background
-        youwinbgTexture = new Texture(Gdx.files.internal("youwin.png"));
-        youwinbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        youwinbg = new TextureRegion(youwinbgTexture, 0, 0, 600, 880);
-
-        //Creating the YouWin screen background
-        youwinAllbgTexture = new Texture(Gdx.files.internal("kicker.gif"));
-        youwinAllbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        youwinAllbg = new TextureRegion(youwinAllbgTexture, 0, 0, 600, 880);
-
-        //Creating the YouLose screen background
-        youlosebgTexture = new Texture(Gdx.files.internal("youlose.png"));
-        youlosebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        youlosebg = new TextureRegion(youlosebgTexture, 0, 0, 600, 880);
-
-
+        
         /** 
          * GameScreen Sprites 
          */
@@ -304,12 +271,6 @@ public class AssetLoader {
      */
     public static void dispose() {
         // We must dispose of the texture when we are finished.
-        youwinbgTexture.dispose();
-        youwinbg.getTexture().dispose();
-        youwinAllbgTexture.dispose();
-        youwinAllbg.getTexture().dispose();
-        youlosebgTexture.dispose();
-        youlosebg.getTexture().dispose();
         ballTexture.dispose();
         ballPopTexture.dispose();
         blue1.getTexture().dispose();

--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -321,11 +321,11 @@ public class BallManager {
         }
         
         //draw the background
-        batch.draw(gameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
+        batch.draw(gameScreen.getBackground(), xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
                 Config.LEVEL_WIDTH, Config.LEVEL_HEIGHT);
         
         /* Draw the brick wall */
-        batch.draw(gameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
+        batch.draw(gameScreen.getBrickWall(), roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
         
         /* Draw shot ball */
         for (Ball ball : ballList) {

--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -11,7 +11,6 @@ import com.badlogic.gdx.math.Rectangle;
 import com.group66.game.BustaMove;
 import com.group66.game.cannon.BallType;
 import com.group66.game.cannon.Ball;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.helpers.ScoreKeeper;
 import com.group66.game.helpers.TextDrawer;

--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -314,18 +314,18 @@ public class BallManager {
      * @param batch the batch used to draw with
      * @param delta the delta
      */
-    public void draw(SpriteBatch batch, float delta) {
+    public void draw(AbstractGameScreen gameScreen, SpriteBatch batch, float delta) {
         int xoffset = Config.SINGLE_PLAYER_OFFSET;
         if (isSplit) {
             xoffset = Config.SEGMENT_OFFSET * segmentOffset;
         }
         
         //draw the background
-        batch.draw(AbstractGameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
+        batch.draw(gameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
                 Config.LEVEL_WIDTH, Config.LEVEL_HEIGHT);
         
         /* Draw the brick wall */
-        batch.draw(AbstractGameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
+        batch.draw(gameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
         
         /* Draw shot ball */
         for (Ball ball : ballList) {

--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -17,6 +17,7 @@ import com.group66.game.helpers.ScoreKeeper;
 import com.group66.game.helpers.TextDrawer;
 import com.group66.game.helpers.TimeKeeper;
 import com.group66.game.logging.MessageType;
+import com.group66.game.screens.AbstractGameScreen;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
 
@@ -314,18 +315,18 @@ public class BallManager {
      * @param batch the batch used to draw with
      * @param delta the delta
      */
-    public void draw(SpriteBatch batch, float delta) {
+    public void draw(AbstractGameScreen gameScreen, SpriteBatch batch, float delta) {
         int xoffset = Config.SINGLE_PLAYER_OFFSET;
         if (isSplit) {
             xoffset = Config.SEGMENT_OFFSET * segmentOffset;
         }
         
         //draw the background
-        batch.draw(AssetLoader.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
+        batch.draw(gameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
                 Config.LEVEL_WIDTH, Config.LEVEL_HEIGHT);
         
         /* Draw the brick wall */
-        batch.draw(AssetLoader.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
+        batch.draw(gameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
         
         /* Draw shot ball */
         for (Ball ball : ballList) {

--- a/core/src/com/group66/game/cannon/BallManager.java
+++ b/core/src/com/group66/game/cannon/BallManager.java
@@ -314,18 +314,18 @@ public class BallManager {
      * @param batch the batch used to draw with
      * @param delta the delta
      */
-    public void draw(AbstractGameScreen gameScreen, SpriteBatch batch, float delta) {
+    public void draw(SpriteBatch batch, float delta) {
         int xoffset = Config.SINGLE_PLAYER_OFFSET;
         if (isSplit) {
             xoffset = Config.SEGMENT_OFFSET * segmentOffset;
         }
         
         //draw the background
-        batch.draw(gameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
+        batch.draw(AbstractGameScreen.bg, xoffset + Config.BORDER_SIZE_SIDES, Config.BORDER_SIZE_BOT,
                 Config.LEVEL_WIDTH, Config.LEVEL_HEIGHT);
         
         /* Draw the brick wall */
-        batch.draw(gameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
+        batch.draw(AbstractGameScreen.bw, roofHitbox.x, roofHitbox.y + 10, roofHitbox.width, roofHitbox.height);
         
         /* Draw shot ball */
         for (Ball ball : ballList) {

--- a/core/src/com/group66/game/cannon/BallType.java
+++ b/core/src/com/group66/game/cannon/BallType.java
@@ -2,7 +2,6 @@ package com.group66.game.cannon;
 
 import com.badlogic.gdx.graphics.g2d.Animation;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.logging.MessageType;
 
 /**
@@ -19,12 +18,12 @@ public enum BallType {
 
         @Override
         public Animation getAnimation() {
-            return AssetLoader.getBlueAnimation();
+            return BallAnimationLoader.getBlueAnimation();
         }
 
         @Override
         public Animation getPopAnimation() {
-            return AssetLoader.getBluePopAnimation();
+            return BallAnimationLoader.getBluePopAnimation();
         }
     },
     
@@ -37,12 +36,12 @@ public enum BallType {
 
         @Override
         public Animation getAnimation() {
-            return AssetLoader.getGreenAnimation();
+            return BallAnimationLoader.getGreenAnimation();
         }
 
         @Override
         public Animation getPopAnimation() {
-            return AssetLoader.getGreenPopAnimation();
+            return BallAnimationLoader.getGreenPopAnimation();
         }
     },
     
@@ -55,12 +54,12 @@ public enum BallType {
 
         @Override
         public Animation getAnimation() {
-            return AssetLoader.getRedAnimation();
+            return BallAnimationLoader.getRedAnimation();
         }
 
         @Override
         public Animation getPopAnimation() {
-            return AssetLoader.getRedPopAnimation();
+            return BallAnimationLoader.getRedPopAnimation();
         }
     },
     
@@ -73,12 +72,12 @@ public enum BallType {
 
         @Override
         public Animation getAnimation() {
-            return AssetLoader.getYellowAnimation();
+            return BallAnimationLoader.getYellowAnimation();
         }
 
         @Override
         public Animation getPopAnimation() {
-            return AssetLoader.getYellowPopAnimation();
+            return BallAnimationLoader.getYellowPopAnimation();
         }
     },
     
@@ -91,7 +90,7 @@ public enum BallType {
 
         @Override
         public Animation getAnimation() {
-            return AssetLoader.getBombAnimation();
+            return BallAnimationLoader.getBombAnimation();
         }
 
         @Override

--- a/core/src/com/group66/game/helpers/AssetLoader.java
+++ b/core/src/com/group66/game/helpers/AssetLoader.java
@@ -11,12 +11,6 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
  */
 public class AssetLoader {
 
-    /** MainMenuScreen background texture. */
-    private static Texture mmbgTexture;
-    
-    /** MainMenu Screen background texture region. */
-    public static TextureRegion mmbg;
-
     /** YouWin Screen background texture. */
     private static Texture youwinbgTexture;
 
@@ -82,10 +76,6 @@ public class AssetLoader {
         /**
          * MainMenu, YouWin, and YouLose screens Sprites
          */
-        //Creating the MainMenu screen background
-        mmbgTexture = new Texture(Gdx.files.internal("main_menu.png"));
-        mmbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        mmbg = new TextureRegion(mmbgTexture, 0, 0, 600, 880);
 
         //Creating the YouWin screen background
         youwinbgTexture = new Texture(Gdx.files.internal("youwin.png"));
@@ -324,8 +314,6 @@ public class AssetLoader {
      */
     public static void dispose() {
         // We must dispose of the texture when we are finished.
-        mmbgTexture.dispose();
-        mmbg.getTexture().dispose();
         youwinbgTexture.dispose();
         youwinbg.getTexture().dispose();
         youwinAllbgTexture.dispose();

--- a/core/src/com/group66/game/helpers/AssetLoader.java
+++ b/core/src/com/group66/game/helpers/AssetLoader.java
@@ -12,62 +12,62 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 public class AssetLoader {
 
     /** MainMenuScreen background texture. */
-    public static Texture mmbgTexture;
+    private static Texture mmbgTexture;
     
     /** MainMenu Screen background texture region. */
     public static TextureRegion mmbg;
 
     /** YouWin Screen background texture. */
-    public static Texture youwinbgTexture;
+    private static Texture youwinbgTexture;
 
     /** YouWin Screen background texture region. */
     public static TextureRegion youwinbg;
 
     /** YouLose Screen background texture. */
-    public static Texture youlosebgTexture;
+    private static Texture youlosebgTexture;
 
     /** YouLose Screen background texture region. */
     public static TextureRegion youlosebg;
 
     /** YouWin Screen background texture. */
-    public static Texture youwinAllbgTexture;
+    private static Texture youwinAllbgTexture;
 
     /** YouWin Screen background texture region. */
     public static TextureRegion youwinAllbg;
 
     /** YouLose Screen background texture. */
-    public static Texture shopbgTexture;
+    private static Texture shopbgTexture;
 
     /** YouLose Screen background texture region. */
     public static TextureRegion shopbg;
 
     /** GameScreen brick wall texture. */
-    public static Texture bwTexture;
+    private static Texture bwTexture;
 
     /** GameScreen brick wall texture region. */
     public static TextureRegion bw;
 
     /** GameScreen background texture. */
-    public static Texture bgTexture;
+    private static Texture bgTexture;
 
     /** GameScreen background texture region. */
     public static TextureRegion bg;
 
     /** GameScreen Pause background texture. */
-    public static Texture pausebgTexture;
+    private static Texture pausebgTexture;
 
     /** GameScreen Pause background texture region. */
     public static TextureRegion pausebg;
 
     /** The ball texture. */
-    public static Texture ballTexture;
-
-    /** The ball pop texture. */
-    public static Texture ballPopTexture;
+    private static Texture ballTexture;
 
     /** The ball texture regions. */
     private static TextureRegion blue1, blue2, blue3, green1, green2, green3,
         red1, red2, red3, yellow1, yellow2, yellow3;
+    
+    /** The ball pop texture. */
+    private static Texture ballPopTexture;
 
     /** The ball animations. */
     public static Animation blueAnimation, greenAnimation, redAnimation,
@@ -86,7 +86,7 @@ public class AssetLoader {
     private static TextureRegion[] yellowPopTextureRegions = new TextureRegion[7];
 
     /** The bomb texture. */
-    public static Texture bomb;
+    private static Texture bomb;
 
     public static ProfileManager profileManager = new ProfileManager();
 

--- a/core/src/com/group66/game/helpers/AssetLoader.java
+++ b/core/src/com/group66/game/helpers/AssetLoader.java
@@ -35,29 +35,11 @@ public class AssetLoader {
     /** YouWin Screen background texture region. */
     public static TextureRegion youwinAllbg;
 
-    /** YouLose Screen background texture. */
+    /** ShopScreen background texture. */
     private static Texture shopbgTexture;
 
-    /** YouLose Screen background texture region. */
+    /** ShopScreen background texture region. */
     public static TextureRegion shopbg;
-
-    /** GameScreen brick wall texture. */
-    private static Texture bwTexture;
-
-    /** GameScreen brick wall texture region. */
-    public static TextureRegion bw;
-
-    /** GameScreen background texture. */
-    private static Texture bgTexture;
-
-    /** GameScreen background texture region. */
-    public static TextureRegion bg;
-
-    /** GameScreen Pause background texture. */
-    private static Texture pausebgTexture;
-
-    /** GameScreen Pause background texture region. */
-    public static TextureRegion pausebg;
 
     /** The ball texture. */
     private static Texture ballTexture;
@@ -87,6 +69,7 @@ public class AssetLoader {
 
     /** The bomb texture. */
     private static Texture bomb;
+
 
     public static ProfileManager profileManager = new ProfileManager();
 
@@ -127,21 +110,6 @@ public class AssetLoader {
         /** 
          * GameScreen Sprites 
          */
-
-        //creating the brick wall
-        bwTexture = new Texture(Gdx.files.internal("roof.png"));
-        bwTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        bw = new TextureRegion(bwTexture, 0, 0, 600, 880);
-
-        //creating the background
-        bgTexture = new Texture(Gdx.files.internal("purplebg.png"));
-        bgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        bg = new TextureRegion(bgTexture, 0, 0, 128, 220);
-
-        //creating the pause screen
-        pausebgTexture = new Texture(Gdx.files.internal("pause_screen.png"));
-        pausebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        pausebg = new TextureRegion(pausebgTexture, 0, 0, 1800, 880);
 
         //loading the textures for the balls
         ballTexture = new Texture(Gdx.files.internal("ballTextures.png"));
@@ -364,12 +332,6 @@ public class AssetLoader {
         youwinAllbg.getTexture().dispose();
         youlosebgTexture.dispose();
         youlosebg.getTexture().dispose();
-        bwTexture.dispose();
-        bw.getTexture().dispose();
-        bgTexture.dispose();
-        bg.getTexture().dispose();
-        pausebgTexture.dispose();
-        pausebg.getTexture().dispose();
         ballTexture.dispose();
         ballPopTexture.dispose();
         blue1.getTexture().dispose();

--- a/core/src/com/group66/game/helpers/AssetLoader.java
+++ b/core/src/com/group66/game/helpers/AssetLoader.java
@@ -29,12 +29,6 @@ public class AssetLoader {
     /** YouWin Screen background texture region. */
     public static TextureRegion youwinAllbg;
 
-    /** ShopScreen background texture. */
-    private static Texture shopbgTexture;
-
-    /** ShopScreen background texture region. */
-    public static TextureRegion shopbg;
-
     /** The ball texture. */
     private static Texture ballTexture;
 
@@ -92,10 +86,6 @@ public class AssetLoader {
         youlosebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
         youlosebg = new TextureRegion(youlosebgTexture, 0, 0, 600, 880);
 
-        //Creating the Store screen background
-        shopbgTexture = new Texture(Gdx.files.internal("shop.png"));
-        shopbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        shopbg = new TextureRegion(shopbgTexture, 0, 0, 600, 880);
 
         /** 
          * GameScreen Sprites 

--- a/core/src/com/group66/game/helpers/ProfileManager.java
+++ b/core/src/com/group66/game/helpers/ProfileManager.java
@@ -20,7 +20,7 @@ public class ProfileManager {
      * 
      */
     public ProfileManager() {
-        // TODO Auto-generated constructor stub
+        
     }
 
     /**

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -1,6 +1,11 @@
 package com.group66.game.screens;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.input.InputHandler;
 
@@ -23,6 +28,29 @@ public abstract class AbstractGameScreen implements Screen {
     
     /** The input handler. */
     protected InputHandler inputHandler;
+    
+    
+    /**
+     * Initialization of all graphic related o
+     */
+   
+    /** GameScreen background texture. */
+    private static Texture bgTexture;
+
+    /** GameScreen background texture region. */
+    public static TextureRegion bg;
+    /** GameScreen brick wall texture. */
+    private static Texture bwTexture;
+
+    /** GameScreen brick wall texture region. */
+    public static TextureRegion bw;
+
+    /** GameScreen Pause background texture. */
+    private static Texture pausebgTexture;
+
+    /** GameScreen Pause background texture region. */
+    public static TextureRegion pausebg;
+
     
     /**
      * Show
@@ -66,7 +94,34 @@ public abstract class AbstractGameScreen implements Screen {
      * @see com.badlogic.gdx.Screen#dispose()
      */
     public void dispose() {
+        
         AudioManager.stopMusic();
+        bwTexture.dispose();
+        bw.getTexture().dispose();
+        bgTexture.dispose();
+        bg.getTexture().dispose();
+        pausebgTexture.dispose();
+        pausebg.getTexture().dispose();
+        
+    }
+    
+    public void loadRelatedGraphics() {
+        
+        //creating the brick wall
+        bwTexture = new Texture(Gdx.files.internal("roof.png"));
+        bwTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        bw = new TextureRegion(bwTexture, 0, 0, 600, 880);
+
+        //creating the background
+        bgTexture = new Texture(Gdx.files.internal("purplebg.png"));
+        bgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        bg = new TextureRegion(bgTexture, 0, 0, 128, 220);
+
+        //creating the pause screen
+        pausebgTexture = new Texture(Gdx.files.internal("pause_screen.png"));
+        pausebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        pausebg = new TextureRegion(pausebgTexture, 0, 0, 1800, 880);
+        
     }
 
 }

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
-import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.input.InputHandler;

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -34,22 +34,22 @@ public abstract class AbstractGameScreen implements Screen {
      */
    
     /** GameScreen background texture. */
-    private static Texture bgTexture;
+    private Texture bgTexture;
 
     /** GameScreen background texture region. */
-    public static TextureRegion bg;
+    public TextureRegion bg;
     
     /** GameScreen brick wall texture. */
-    private static Texture bwTexture;
+    private Texture bwTexture;
 
     /** GameScreen brick wall texture region. */
-    public static TextureRegion bw;
+    public TextureRegion bw;
 
     /** GameScreen Pause background texture. */
-    private static Texture pausebgTexture;
+    private Texture pausebgTexture;
 
     /** GameScreen Pause background texture region. */
-    public static TextureRegion pausebg;
+    public TextureRegion pausebg;
 
     
     /**
@@ -108,8 +108,7 @@ public abstract class AbstractGameScreen implements Screen {
     /**
      * loads related Graphics
      */
-    public void loadRelatedGraphics() {
-        
+    public void loadRelatedGraphics() {      
         //creating the brick wall
         bwTexture = new Texture(Gdx.files.internal("roof.png"));
         bwTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
@@ -123,8 +122,24 @@ public abstract class AbstractGameScreen implements Screen {
         //creating the pause screen
         pausebgTexture = new Texture(Gdx.files.internal("pause_screen.png"));
         pausebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-        pausebg = new TextureRegion(pausebgTexture, 0, 0, 1800, 880);
-        
+        pausebg = new TextureRegion(pausebgTexture, 0, 0, 1800, 880);       
     }
-
+    
+    /**
+     * get the background
+     * @return bg
+     */
+    public TextureRegion getBackground() {
+        return this.bg;
+    }
+    
+    /**
+     * get the brickwall
+     * @return bw
+     */
+    public TextureRegion getBrickWall() {
+        return this.bw;
+    }
+    
+    
 }

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -39,6 +39,7 @@ public abstract class AbstractGameScreen implements Screen {
 
     /** GameScreen background texture region. */
     public static TextureRegion bg;
+    
     /** GameScreen brick wall texture. */
     private static Texture bwTexture;
 

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -105,6 +105,9 @@ public abstract class AbstractGameScreen implements Screen {
         
     }
     
+    /**
+     * loads related Graphics
+     */
     public void loadRelatedGraphics() {
         
         //creating the brick wall

--- a/core/src/com/group66/game/screens/AbstractGameScreen.java
+++ b/core/src/com/group66/game/screens/AbstractGameScreen.java
@@ -37,19 +37,19 @@ public abstract class AbstractGameScreen implements Screen {
     private Texture bgTexture;
 
     /** GameScreen background texture region. */
-    public TextureRegion bg;
+    private TextureRegion bg;
     
     /** GameScreen brick wall texture. */
     private Texture bwTexture;
 
     /** GameScreen brick wall texture region. */
-    public TextureRegion bw;
+    private TextureRegion bw;
 
     /** GameScreen Pause background texture. */
     private Texture pausebgTexture;
 
     /** GameScreen Pause background texture region. */
-    public TextureRegion pausebg;
+    private TextureRegion pausebg;
 
     
     /**
@@ -141,5 +141,12 @@ public abstract class AbstractGameScreen implements Screen {
         return this.bw;
     }
     
+    /**
+     * get the pause background
+     * @return pausebg
+     */
+    public TextureRegion getPauseBackground() {
+        return this.pausebg;
+    }
     
 }

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -17,7 +17,7 @@ import com.group66.game.settings.Config;
 
 public abstract class AbstractMenuScreen implements Screen {
     /** A place to store the game instance. */
-    protected BustaMove game;
+    public BustaMove game = BustaMove.getGameInstance();
 
     public Stage stage;
     
@@ -31,9 +31,7 @@ public abstract class AbstractMenuScreen implements Screen {
     /** MainMenu Screen background texture region. */
     public static TextureRegion mmbg;
 
-    private void createScreen() {  
-     }
-
+    
     public void render(float delta) {
     }
 
@@ -54,8 +52,8 @@ public abstract class AbstractMenuScreen implements Screen {
     }
 
     public void dispose() {
-        mmbgTexture.dispose();
-        mmbg.getTexture().dispose();
+        stage.dispose();
+        skin.dispose();
     }
     
     /**

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -15,14 +15,20 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.group66.game.BustaMove;
 import com.group66.game.settings.Config;
 
+/**
+ * The Class AbstractMenuScreen.
+ */
 public abstract class AbstractMenuScreen implements Screen {
     /** A place to store the game instance. */
     public BustaMove game = BustaMove.getGameInstance();
 
+    /** The stage. */
     public Stage stage;
     
+    /** The skin. */
     protected Skin skin;
     
+    /** The text button style. */
     public TextButtonStyle textButtonStyle;
     
     /** MainMenuScreen background texture. */
@@ -32,32 +38,53 @@ public abstract class AbstractMenuScreen implements Screen {
     public static TextureRegion mmbg;
 
     
+    /** 
+     * @see com.badlogic.gdx.Screen#render(float)
+     */
     public void render(float delta) {
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#show()
+     */
     public void show() {
     
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#resize(int, int)
+     */
     public void resize(int width, int height) {
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#pause()
+     */
     public void pause() {
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#resume()
+     */
     public void resume() {
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#hide()
+     */
     public void hide() {
     }
 
+    /**
+     * @see com.badlogic.gdx.Screen#dispose()
+     */
     public void dispose() {
         stage.dispose();
         skin.dispose();
     }
     
     /**
-     * Loads related graphics
+     * Loads related graphics.
      */
     public void loadRelatedGraphics() {
         //Creating the MainMenu screen background
@@ -67,11 +94,14 @@ public abstract class AbstractMenuScreen implements Screen {
     }
     
     /**
-     * sets up screen related buttons
+     * sets up screen related buttons.
      */
     public void setupButtons() {        
     }
     
+    /**
+     * Load button materials.
+     */
     public void loadButtonMaterials() {
         skin = new Skin();
         // Store the default libgdx font under the name "default".

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -1,0 +1,100 @@
+package com.group66.game.screens;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
+import com.group66.game.BustaMove;
+import com.group66.game.settings.Config;
+
+public abstract class AbstractMenuScreen implements Screen {
+    /** A place to store the game instance. */
+    protected BustaMove game;
+
+    public Stage stage;
+    
+    protected Skin skin;
+    
+    protected TextButtonStyle textButtonStyle;
+    
+    /** MainMenuScreen background texture. */
+    private static Texture mmbgTexture;
+    
+    /** MainMenu Screen background texture region. */
+    public static TextureRegion mmbg;
+
+    private void createScreen() {  
+     }
+
+    public void render(float delta) {
+    }
+
+    public void show() {
+    
+    }
+
+    public void resize(int width, int height) {
+    }
+
+    public void pause() {
+    }
+
+    public void resume() {
+    }
+
+    public void hide() {
+    }
+
+    public void dispose() {
+        mmbgTexture.dispose();
+        mmbg.getTexture().dispose();
+    }
+    
+    /**
+     * Loads related graphics
+     */
+    public void loadRelatedGraphics() {
+        //Creating the MainMenu screen background
+        mmbgTexture = new Texture(Gdx.files.internal("main_menu.png"));
+        mmbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        mmbg = new TextureRegion(mmbgTexture, 0, 0, 600, 880);
+    }
+    
+    /**
+     * sets up screen related buttons
+     */
+    public void setupButtons() {        
+    }
+    
+    public void loadButtonMaterials() {
+        skin = new Skin();
+        // Store the default libgdx font under the name "default".
+        BitmapFont bfont = new BitmapFont();
+        skin.add("default", bfont);
+
+        // Generate a 1x1 white texture and store it in the skin named "white".
+        Pixmap pixmap = new Pixmap(Config.BUTTON_WIDTH, Config.BUTTON_HEIGHT, Format.RGBA8888);
+        pixmap.setColor(Color.WHITE);
+        pixmap.fill();
+        skin.add("white", new Texture(pixmap));
+
+        // Configure a TextButtonStyle and name it "default". Skin resources are
+        // stored by type, so this doesn't overwrite the font.
+        textButtonStyle = new TextButtonStyle();
+        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
+        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
+        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
+        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
+        textButtonStyle.font = skin.getFont("default");
+        skin.add("default", textButtonStyle);
+    }
+
+}

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -23,7 +23,7 @@ public abstract class AbstractMenuScreen implements Screen {
     public BustaMove game = BustaMove.getGameInstance();
 
     /** The stage. */
-    public Stage stage;
+    protected Stage stage;
     
     /** The skin. */
     protected Skin skin;
@@ -32,10 +32,10 @@ public abstract class AbstractMenuScreen implements Screen {
     public TextButtonStyle textButtonStyle;
     
     /** MainMenuScreen background texture. */
-    private static Texture mmbgTexture;
+    private Texture mmbgTexture;
     
     /** MainMenu Screen background texture region. */
-    public static TextureRegion mmbg;
+    public TextureRegion mmbg;
 
     
     /** 

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -23,7 +23,7 @@ public abstract class AbstractMenuScreen implements Screen {
     
     protected Skin skin;
     
-    protected TextButtonStyle textButtonStyle;
+    public TextButtonStyle textButtonStyle;
     
     /** MainMenuScreen background texture. */
     private static Texture mmbgTexture;

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -35,7 +35,7 @@ public abstract class AbstractMenuScreen implements Screen {
     private Texture mmbgTexture;
     
     /** MainMenu Screen background texture region. */
-    public TextureRegion mmbg;
+    protected TextureRegion mmbg;
 
     
     /** 

--- a/core/src/com/group66/game/screens/AbstractMenuScreen.java
+++ b/core/src/com/group66/game/screens/AbstractMenuScreen.java
@@ -12,16 +12,13 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
-import com.group66.game.BustaMove;
 import com.group66.game.settings.Config;
 
 /**
  * The Class AbstractMenuScreen.
  */
 public abstract class AbstractMenuScreen implements Screen {
-    /** A place to store the game instance. */
-    public BustaMove game = BustaMove.getGameInstance();
-
+    
     /** The stage. */
     protected Stage stage;
     
@@ -29,7 +26,7 @@ public abstract class AbstractMenuScreen implements Screen {
     protected Skin skin;
     
     /** The text button style. */
-    public TextButtonStyle textButtonStyle;
+    protected TextButtonStyle textButtonStyle;
     
     /** MainMenuScreen background texture. */
     private Texture mmbgTexture;

--- a/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
@@ -40,9 +40,7 @@ public abstract class AbstractYouLoseScreen implements Screen {
 
     protected void createScreen() { }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#render(float)
      */
     @Override
@@ -61,9 +59,7 @@ public abstract class AbstractYouLoseScreen implements Screen {
         stage.draw();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#show()
      */
     @Override
@@ -71,9 +67,7 @@ public abstract class AbstractYouLoseScreen implements Screen {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#resize(int, int)
      */
     @Override
@@ -81,36 +75,28 @@ public abstract class AbstractYouLoseScreen implements Screen {
         
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#pause()
      */
     @Override
     public void pause() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /** 
      * @see com.badlogic.gdx.Screen#resume()
      */
     @Override
     public void resume() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#hide()
      */
     @Override
     public void hide() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#dispose()
      */
     @Override
@@ -119,6 +105,9 @@ public abstract class AbstractYouLoseScreen implements Screen {
         youlosebg.getTexture().dispose();
     }
     
+    /**
+     * loads related graphics
+     */
     public void loadRelatedGraphics() {
       //Creating the YouLose screen background
         youlosebgTexture = new Texture(Gdx.files.internal("youlose.png"));

--- a/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
@@ -3,9 +3,11 @@ package com.group66.game.screens;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
 import com.group66.game.BustaMove;
@@ -13,17 +15,25 @@ import com.group66.game.BustaMove;
 /**
  * A Class for the MainMenuScreen of the game.
  */
-public class AbstractYouLoseScreen implements Screen {
+public abstract class AbstractYouLoseScreen implements Screen {
 
     protected Stage stage;
     protected Skin skin;
     protected DynamicSettings dynamicSettings;
 
+    /** 
+     * Textures for the sprites
+     */
+    /** YouLose Screen background texture. */
+    private static Texture youlosebgTexture;
+
+    /** YouLose Screen background texture region. */
+    public static TextureRegion youlosebg;
+    
     /**
      * Instantiates a new main menu screen.
      */
     public AbstractYouLoseScreen(DynamicSettings dynamicSettings) {
-        AssetLoader.load();
         this.dynamicSettings = dynamicSettings;
         createScreen();
     }
@@ -43,7 +53,7 @@ public class AbstractYouLoseScreen implements Screen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.youlosebg, 
+        BustaMove.getGameInstance().batch.draw(youlosebg, 
                 Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH, Gdx.graphics.getHeight());
         BustaMove.getGameInstance().batch.end();
         
@@ -68,7 +78,7 @@ public class AbstractYouLoseScreen implements Screen {
      */
     @Override
     public void resize(int width, int height) {
-        // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+        
     }
 
     /*
@@ -105,6 +115,16 @@ public class AbstractYouLoseScreen implements Screen {
      */
     @Override
     public void dispose() {
+        youlosebgTexture.dispose();
+        youlosebg.getTexture().dispose();
+    }
+    
+    public void loadRelatedGraphics() {
+      //Creating the YouLose screen background
+        youlosebgTexture = new Texture(Gdx.files.internal("youlose.png"));
+        youlosebgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        youlosebg = new TextureRegion(youlosebgTexture, 0, 0, 600, 880);
 
     }
+    
 }

--- a/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
@@ -28,7 +28,7 @@ public abstract class AbstractYouLoseScreen implements Screen {
     private Texture youlosebgTexture;
 
     /** YouLose Screen background texture region. */
-    public TextureRegion youlosebg;
+    protected TextureRegion youlosebg;
     
     /**
      * Instantiates a new main menu screen.
@@ -103,6 +103,8 @@ public abstract class AbstractYouLoseScreen implements Screen {
     public void dispose() {
         youlosebgTexture.dispose();
         youlosebg.getTexture().dispose();
+        stage.dispose();
+        skin.dispose();
     }
     
     /**

--- a/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouLoseScreen.java
@@ -25,10 +25,10 @@ public abstract class AbstractYouLoseScreen implements Screen {
      * Textures for the sprites
      */
     /** YouLose Screen background texture. */
-    private static Texture youlosebgTexture;
+    private Texture youlosebgTexture;
 
     /** YouLose Screen background texture region. */
-    public static TextureRegion youlosebg;
+    public TextureRegion youlosebg;
     
     /**
      * Instantiates a new main menu screen.

--- a/core/src/com/group66/game/screens/AbstractYouWinScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouWinScreen.java
@@ -30,16 +30,16 @@ public abstract class AbstractYouWinScreen implements Screen {
      * Textures for the sprites
      */
     /** YouWin Screen background texture. */
-    private static Texture youwinbgTexture;
+    private Texture youwinbgTexture;
 
     /** YouWin Screen background texture region. */
-    public static TextureRegion youwinbg;
+    public TextureRegion youwinbg;
     
     /** YouWin Screen background texture. */
-    private static Texture youwinAllbgTexture;
+    private Texture youwinAllbgTexture;
 
     /** YouWin Screen background texture region. */
-    public static TextureRegion youwinAllbg;
+    public TextureRegion youwinAllbg;
     
     
     /**

--- a/core/src/com/group66/game/screens/AbstractYouWinScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouWinScreen.java
@@ -82,9 +82,7 @@ public abstract class AbstractYouWinScreen implements Screen {
 
     protected void makeButtons(TextButtonStyle textButtonStyle) { };
 
-    /*
-     * (non-Javadoc)
-     * 
+    /** 
      * @see com.badlogic.gdx.Screen#render(float)
      */
     @Override
@@ -92,9 +90,7 @@ public abstract class AbstractYouWinScreen implements Screen {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#show()
      */
     @Override
@@ -102,9 +98,7 @@ public abstract class AbstractYouWinScreen implements Screen {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#resize(int, int)
      */
     @Override
@@ -112,36 +106,28 @@ public abstract class AbstractYouWinScreen implements Screen {
         // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#pause()
      */
     @Override
     public void pause() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#resume()
      */
     @Override
     public void resume() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#hide()
      */
     @Override
     public void hide() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
+    /**
      * @see com.badlogic.gdx.Screen#dispose()
      */
     @Override
@@ -152,6 +138,9 @@ public abstract class AbstractYouWinScreen implements Screen {
         youwinAllbg.getTexture().dispose();
     }
     
+    /**
+     * loads related graphics
+     */
     public void loadRelatedGraphics() {
         //Creating the YouWin screen background
         youwinbgTexture = new Texture(Gdx.files.internal("youwin.png"));

--- a/core/src/com/group66/game/screens/AbstractYouWinScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouWinScreen.java
@@ -33,13 +33,13 @@ public abstract class AbstractYouWinScreen implements Screen {
     private Texture youwinbgTexture;
 
     /** YouWin Screen background texture region. */
-    public TextureRegion youwinbg;
+    protected TextureRegion youwinbg;
     
     /** YouWin Screen background texture. */
     private Texture youwinAllbgTexture;
 
     /** YouWin Screen background texture region. */
-    public TextureRegion youwinAllbg;
+    protected TextureRegion youwinAllbg;
     
     
     /**
@@ -136,6 +136,8 @@ public abstract class AbstractYouWinScreen implements Screen {
         youwinbg.getTexture().dispose();
         youwinAllbgTexture.dispose();
         youwinAllbg.getTexture().dispose();
+        stage.dispose();
+        skin.dispose();
     }
     
     /**

--- a/core/src/com/group66/game/screens/AbstractYouWinScreen.java
+++ b/core/src/com/group66/game/screens/AbstractYouWinScreen.java
@@ -3,21 +3,20 @@ package com.group66.game.screens;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
-import com.group66.game.BustaMove;
 
 /**
- * A Class for the MainMenuScreen of the game.
+ * A Class for the YouWinuScreen of the game.
  */
 public abstract class AbstractYouWinScreen implements Screen {
 
@@ -26,13 +25,29 @@ public abstract class AbstractYouWinScreen implements Screen {
     
     protected DynamicSettings dynamicSettings;
 
+    
+    /**
+     * Textures for the sprites
+     */
+    /** YouWin Screen background texture. */
+    private static Texture youwinbgTexture;
+
+    /** YouWin Screen background texture region. */
+    public static TextureRegion youwinbg;
+    
+    /** YouWin Screen background texture. */
+    private static Texture youwinAllbgTexture;
+
+    /** YouWin Screen background texture region. */
+    public static TextureRegion youwinAllbg;
+    
+    
     /**
      * Instantiates a new main menu screen.
      * @param dynamicSettings TODO
      */
     public AbstractYouWinScreen(DynamicSettings dynamicSettings) {
         this.dynamicSettings = dynamicSettings;
-        AssetLoader.load();
         createScreen();
     }
 
@@ -74,18 +89,7 @@ public abstract class AbstractYouWinScreen implements Screen {
      */
     @Override
     public void render(float delta) {
-        Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-        /* Draw the background */
-        BustaMove.getGameInstance().batch.begin();
-        BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.youwinbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
-                Gdx.graphics.getHeight());
-        BustaMove.getGameInstance().batch.end();
-
-        stage.act();
-        stage.draw();
     }
 
     /*
@@ -142,6 +146,21 @@ public abstract class AbstractYouWinScreen implements Screen {
      */
     @Override
     public void dispose() {
+        youwinbgTexture.dispose();
+        youwinbg.getTexture().dispose();
+        youwinAllbgTexture.dispose();
+        youwinAllbg.getTexture().dispose();
+    }
+    
+    public void loadRelatedGraphics() {
+        //Creating the YouWin screen background
+        youwinbgTexture = new Texture(Gdx.files.internal("youwin.png"));
+        youwinbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        youwinbg = new TextureRegion(youwinbgTexture, 0, 0, 600, 880);
 
+        //Creating the YouWin screen background
+        youwinAllbgTexture = new Texture(Gdx.files.internal("kicker.gif"));
+        youwinAllbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        youwinAllbg = new TextureRegion(youwinAllbgTexture, 0, 0, 600, 880);      
     }
 }

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -4,19 +4,11 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
-import com.group66.game.helpers.HighScoreManager;
 import com.group66.game.helpers.TextDrawer;
 import com.group66.game.input.LevelSelectInputListener;
 import com.group66.game.logging.MessageType;
@@ -27,27 +19,25 @@ import com.group66.game.settings.DynamicSettings;
  * A Class for the MainMenuScreen of the game.
  */
 public class CareerScreen extends AbstractMenuScreen {
-    /** A place to store the game instance. */
-    private BustaMove game;
-
-    private Stage stage;
-    private Skin skin;
-
-    private TextButton chooseButton;
-
     private static DynamicSettings dynamicSettings = new DynamicSettings();
 
     /** The text drawer. */
     private TextDrawer textDrawer;
 
     private Screen ownInstance;
+    
+    /** screen buttons */
+    private TextButton levelButton;
+    private TextButton chooseButton;
+    private TextButton approveButton;
+    private TextButton resetButton;
+    private TextButton exitButton;
+    private TextButton shopButton;
 
     /**
      * Instantiates a new main menu screen.
      */
     public CareerScreen() {
-        this.game = BustaMove.getGameInstance();
-        AssetLoader.load();
         BustaMove.getGameInstance().getHighScoreManager().loadData();
         ownInstance = this;
         createScreen();
@@ -64,110 +54,19 @@ public class CareerScreen extends AbstractMenuScreen {
     }
 
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-        skin = new Skin();
-
         // Setup the text drawer to show the amount of coins
         textDrawer = new TextDrawer();
         textDrawer.myFont.setColor(Color.BLACK);
-
-        // Store the default libgdx font under the name "default".
-        BitmapFont bfont = new BitmapFont();
-        skin.add("default", bfont);
-
-        // Generate a 1x1 white texture and store it in the skin named "white".
-        Pixmap pixmap = new Pixmap(Config.BUTTON_WIDTH, Config.BUTTON_HEIGHT, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-
-        // Configure a TextButtonStyle and name it "default". Skin resources are
-        // stored by type, so this doesn't overwrite the font.
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
-        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-
-        //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2);
-
-        TextButton levelButton = new TextButton("Play: Level " + (dynamicSettings.getLevelCleared() + 1), 
-                textButtonStyle);
-        levelButton.setPosition(centercol, yoffset);
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
-        chooseButton = new TextButton("Choose level: ", textButtonStyle);
-        chooseButton.setPosition(leftcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        TextButton approveButton = new TextButton("Play", textButtonStyle);
-        approveButton.setPosition(rightcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        TextButton resetButton = new TextButton("Reset career", textButtonStyle);
-        resetButton.setPosition(centercol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        TextButton shopButton = new TextButton("Shop", textButtonStyle);
-        shopButton.setPosition(centercol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        TextButton exitButton = new TextButton("Exit", textButtonStyle);
-        exitButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
+        setupButtons();
         stage.addActor(levelButton);
         stage.addActor(chooseButton);
         stage.addActor(approveButton);
         stage.addActor(resetButton);
         stage.addActor(exitButton);
-        stage.addActor(shopButton);
-
-        // Add a listener to the button. ChangeListener is fired when the
-        // button's checked state changes, eg when clicked,
-        // Button#setChecked() is called, via a key press, etc. If the
-        // event.cancel() is called, the checked state will be reverted.
-        // ClickListener could have been used, but would only fire when clicked.
-        // Also, canceling a ClickListener event won't
-        // revert the checked state.
-        levelButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dispose();
-                dynamicSettings.setCurrentLevel(dynamicSettings.getLevelCleared() + 1);
-                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
-            }
-        });
-        chooseButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                LevelSelectInputListener listener = new LevelSelectInputListener(dynamicSettings);
-                Gdx.input.getTextInput(listener, "Choose level", "", "Number between 1 and" 
-                        + dynamicSettings.getLevelCleared());
-            }
-        });
-        approveButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dispose();
-                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
-            }
-        });
-        resetButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dynamicSettings.reset();
-            }
-        });
-        exitButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dispose();
-                game.setScreen(new MainMenuScreen());
-            }
-        });
-
-        shopButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dispose();
-                game.setScreen(new ShopScreen(dynamicSettings, ownInstance));
-            }
-        });
+        stage.addActor(shopButton);       
     }
 
     /*
@@ -213,7 +112,7 @@ public class CareerScreen extends AbstractMenuScreen {
      */
     @Override
     public void resize(int width, int height) {
-        // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+       
     }
 
     /*
@@ -241,6 +140,81 @@ public class CareerScreen extends AbstractMenuScreen {
      */
     @Override
     public void hide() {
+    }
+    
+    @Override
+    public void setupButtons() {
+        loadButtonMaterials();
+        //all magic numbers in this section are offsets values adjusted to get better looks
+        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        int centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2);
+
+        levelButton = new TextButton("Play: Level " + (dynamicSettings.getLevelCleared() + 1), 
+                textButtonStyle);
+        levelButton.setPosition(centercol, yoffset);
+        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+        chooseButton = new TextButton("Choose level: ", textButtonStyle);
+        chooseButton.setPosition(leftcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        approveButton = new TextButton("Play", textButtonStyle);
+        approveButton.setPosition(rightcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        resetButton = new TextButton("Reset career", textButtonStyle);
+        resetButton.setPosition(centercol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        shopButton = new TextButton("Shop", textButtonStyle);
+        shopButton.setPosition(centercol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        exitButton = new TextButton("Exit", textButtonStyle);
+        exitButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+        
+        // Add a listener to the button. ChangeListener is fired when the
+        // button's checked state changes, eg when clicked,
+        // Button#setChecked() is called, via a key press, etc. If the
+        // event.cancel() is called, the checked state will be reverted.
+        // ClickListener could have been used, but would only fire when clicked.
+        // Also, canceling a ClickListener event won't
+        // revert the checked state.
+        levelButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dispose();
+                dynamicSettings.setCurrentLevel(dynamicSettings.getLevelCleared() + 1);
+                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
+            }
+        });
+        chooseButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                LevelSelectInputListener listener = new LevelSelectInputListener(dynamicSettings);
+                Gdx.input.getTextInput(listener, "Choose level", "", "Number between 1 and" 
+                        + dynamicSettings.getLevelCleared());
+            }
+        });
+        approveButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dispose();
+                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
+            }
+        });
+        resetButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dynamicSettings.reset();
+            }
+        });
+        exitButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dispose();
+                game.setScreen(new MainMenuScreen());
+            }
+        });
+
+        shopButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dispose();
+                game.setScreen(new ShopScreen(dynamicSettings, ownInstance));
+            }
+        });
+        
     }
 
 }

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -94,54 +94,7 @@ public class CareerScreen extends AbstractMenuScreen {
         stage.act();
         stage.draw();
     }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-       
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#hide()
-     */
-    @Override
-    public void hide() {
-    }
-    
+   
     @Override
     public void setupButtons() {
         loadButtonMaterials();

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -243,14 +243,4 @@ public class CareerScreen extends AbstractMenuScreen {
     public void hide() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#dispose()
-     */
-    @Override
-    public void dispose() {
-        stage.dispose();
-        skin.dispose();
-    }
 }

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -31,7 +31,7 @@ public class CareerScreen extends AbstractMenuScreen {
     private TextButton chooseButton;
     private TextButton approveButton;
     private TextButton resetButton;
-    private TextButton exitButton;
+    private TextButton mainMenuButton;
     private TextButton shopButton;
 
     /**
@@ -65,7 +65,7 @@ public class CareerScreen extends AbstractMenuScreen {
         stage.addActor(chooseButton);
         stage.addActor(approveButton);
         stage.addActor(resetButton);
-        stage.addActor(exitButton);
+        stage.addActor(mainMenuButton);
         stage.addActor(shopButton);       
     }
 
@@ -119,8 +119,8 @@ public class CareerScreen extends AbstractMenuScreen {
         shopButton = new TextButton("Shop", textButtonStyle);
         shopButton.setPosition(centercol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
 
-        exitButton = new TextButton("Exit", textButtonStyle);
-        exitButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+        mainMenuButton = new TextButton("Main Menu", textButtonStyle);
+        mainMenuButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
         
         // Add a listener to the button. ChangeListener is fired when the
         // button's checked state changes, eg when clicked,
@@ -154,7 +154,7 @@ public class CareerScreen extends AbstractMenuScreen {
                 dynamicSettings.reset();
             }
         });
-        exitButton.addListener(new ChangeListener() {
+        mainMenuButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
                 game.setScreen(new MainMenuScreen());

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -26,7 +26,7 @@ import com.group66.game.settings.DynamicSettings;
 /**
  * A Class for the MainMenuScreen of the game.
  */
-public class CareerScreen implements Screen {
+public class CareerScreen extends AbstractMenuScreen {
     /** A place to store the game instance. */
     private BustaMove game;
 
@@ -185,7 +185,7 @@ public class CareerScreen implements Screen {
         /* Draw the background */
         game.batch.begin();
         game.batch.enableBlending();
-        game.batch.draw(AssetLoader.mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        game.batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         textDrawer.draw(BustaMove.getGameInstance().batch, "You have cleared " 
                 + dynamicSettings.getLevelCleared() + " out of " + Config.NUMBER_OF_LEVELS + " levels!", 

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -88,14 +88,14 @@ public class CareerScreen extends AbstractMenuScreen {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
         /* Draw the background */
-        game.batch.begin();
-        game.batch.enableBlending();
-        game.batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        BustaMove.getGameInstance().batch.begin();
+        BustaMove.getGameInstance().batch.enableBlending();
+        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         textDrawer.draw(BustaMove.getGameInstance().batch, "You have cleared " 
                 + dynamicSettings.getLevelCleared() + " out of " + Config.NUMBER_OF_LEVELS + " levels!", 
                 Config.WIDTH / 2 - Config.LEVEL_WIDTH / 2 + Config.CURRENCY_X - 100, Config.CURRENCY_Y - 50);
-        game.batch.end();
+        BustaMove.getGameInstance().batch.end();
 
         stage.act();
         stage.draw();
@@ -138,7 +138,7 @@ public class CareerScreen extends AbstractMenuScreen {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
                 dynamicSettings.setCurrentLevel(dynamicSettings.getLevelCleared() + 1);
-                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
+                BustaMove.getGameInstance().setScreen(new OnePlayerGameScreen(false, dynamicSettings));
             }
         });
         chooseButton.addListener(new ChangeListener() {
@@ -151,7 +151,7 @@ public class CareerScreen extends AbstractMenuScreen {
         approveButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new OnePlayerGameScreen(false, dynamicSettings));
+                BustaMove.getGameInstance().setScreen(new OnePlayerGameScreen(false, dynamicSettings));
             }
         });
         resetButton.addListener(new ChangeListener() {
@@ -162,14 +162,14 @@ public class CareerScreen extends AbstractMenuScreen {
         mainMenuButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new MainMenuScreen());
+                BustaMove.getGameInstance().setScreen(new MainMenuScreen());
             }
         });
 
         shopButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new ShopScreen(dynamicSettings, ownInstance));
+                BustaMove.getGameInstance().setScreen(new ShopScreen(dynamicSettings, ownInstance));
             }
         });
         

--- a/core/src/com/group66/game/screens/CareerScreen.java
+++ b/core/src/com/group66/game/screens/CareerScreen.java
@@ -33,6 +33,12 @@ public class CareerScreen extends AbstractMenuScreen {
     private TextButton resetButton;
     private TextButton mainMenuButton;
     private TextButton shopButton;
+    
+    /** variables used to calculate some drawing coordinates */
+    private int yoffset;
+    private int centercol;
+    private int leftcol;
+    private int rightcol;
 
     /**
      * Instantiates a new main menu screen.
@@ -94,22 +100,21 @@ public class CareerScreen extends AbstractMenuScreen {
         stage.act();
         stage.draw();
     }
-   
+
     @Override
     public void setupButtons() {
         loadButtonMaterials();
         //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2);
+        yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2);
 
         levelButton = new TextButton("Play: Level " + (dynamicSettings.getLevelCleared() + 1), 
                 textButtonStyle);
         levelButton.setPosition(centercol, yoffset);
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+        leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
         chooseButton = new TextButton("Choose level: ", textButtonStyle);
         chooseButton.setPosition(leftcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
         approveButton = new TextButton("Play", textButtonStyle);
         approveButton.setPosition(rightcol, yoffset - 1 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
 

--- a/core/src/com/group66/game/screens/HighScoreScreen.java
+++ b/core/src/com/group66/game/screens/HighScoreScreen.java
@@ -86,6 +86,7 @@ public class HighScoreScreen extends AbstractMenuScreen {
         backButton.setPosition(xoffset + labelwidth, labelheight);
         backButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
+                dispose();
                 BustaMove.getGameInstance().setScreen(new MainMenuScreen());
             }
         });

--- a/core/src/com/group66/game/screens/HighScoreScreen.java
+++ b/core/src/com/group66/game/screens/HighScoreScreen.java
@@ -1,28 +1,27 @@
 package com.group66.game.screens;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
 import com.group66.game.helpers.HighScoreItem;
 import com.group66.game.settings.Config;
 
-public class HighScoreScreen implements Screen {
+public class HighScoreScreen extends AbstractMenuScreen {
+    /** sets up buttons */
+    private TextButton backButton;
     
-    private Stage stage;
+    /** variables to calculate label locations */
+    private float labelheight;
+    private float labelwidth;
+    private float xoffset;
+    private float yoffset;
     
     /**
      * Constructor for the high score screen
@@ -35,12 +34,13 @@ public class HighScoreScreen implements Screen {
      * Create the stage for the highscore screen
      */
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
         
-        float labelheight = Config.HEIGHT / 13f;
-        float labelwidth = 2f * labelheight;
-        float xoffset = Math.max((Config.WIDTH - 3f * labelwidth) / 2f, 0);
+        labelheight = Config.HEIGHT / 13f;
+        labelwidth = 2f * labelheight;
+        xoffset = Math.max((Config.WIDTH - 3f * labelwidth) / 2f, 0);
         
         LabelStyle labelStyle = new LabelStyle();
         labelStyle.font = new BitmapFont();
@@ -53,7 +53,7 @@ public class HighScoreScreen implements Screen {
             }
             count++;
             
-            float yoffset = Config.HEIGHT - count * labelheight;
+            yoffset = Config.HEIGHT - count * labelheight;
             
             Label name = new Label(hsi.name, labelStyle);
             name.setPosition(xoffset, yoffset);
@@ -65,34 +65,8 @@ public class HighScoreScreen implements Screen {
             score.setPosition(xoffset + 2 * labelwidth, yoffset);
             stage.addActor(score);
         }
-        
-        //create skin for back button
-        Skin skin = new Skin();
-        skin.add("default", new BitmapFont());
-        
-        Pixmap pixmap = new Pixmap((int) labelwidth, (int) labelheight, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-        
-        //back button style
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.font = skin.getFont("default");
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.BLACK);
-        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        skin.add("default", textButtonStyle);
-        
-        //back button
-        TextButton backButton = new TextButton("Back", textButtonStyle);
-        backButton.setPosition(xoffset + labelwidth, labelheight);
+        setupButtons();
         stage.addActor(backButton);
-        backButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                BustaMove.getGameInstance().setScreen(new MainMenuScreen());
-            }
-        });
     }
     
     @Override
@@ -123,8 +97,17 @@ public class HighScoreScreen implements Screen {
     @Override
     public void hide() {
     }
-
+    
     @Override
-    public void dispose() {
+    public void setupButtons() {
+        loadButtonMaterials();
+        //back button listener
+        backButton = new TextButton("Back", textButtonStyle);
+        backButton.setPosition(xoffset + labelwidth, labelheight);
+        backButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                BustaMove.getGameInstance().setScreen(new MainMenuScreen());
+            }
+        });
     }
 }

--- a/core/src/com/group66/game/screens/HighScoreScreen.java
+++ b/core/src/com/group66/game/screens/HighScoreScreen.java
@@ -67,11 +67,7 @@ public class HighScoreScreen extends AbstractMenuScreen {
         }
         setupButtons();
         stage.addActor(backButton);
-    }
-    
-    @Override
-    public void show() {
-    }
+    }   
 
     @Override
     public void render(float delta) {
@@ -80,22 +76,6 @@ public class HighScoreScreen extends AbstractMenuScreen {
 
         stage.act(delta);
         stage.draw();
-    }
-
-    @Override
-    public void resize(int width, int height) {
-    }
-
-    @Override
-    public void pause() {
-    }
-
-    @Override
-    public void resume() {
-    }
-
-    @Override
-    public void hide() {
     }
     
     @Override

--- a/core/src/com/group66/game/screens/MainMenuScreen.java
+++ b/core/src/com/group66/game/screens/MainMenuScreen.java
@@ -147,20 +147,20 @@ public class MainMenuScreen extends AbstractMenuScreen {
         levelButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new CareerScreen());
+                BustaMove.getGameInstance().setScreen(new CareerScreen());
             }
         });
         randomButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
                 dynamicSettings.setRandomLevel(true);
-                game.setScreen(new OnePlayerGameScreen(true, dynamicSettings));
+                BustaMove.getGameInstance().setScreen(new OnePlayerGameScreen(true, dynamicSettings));
             }
         });
         scoresButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new HighScoreScreen());
+                BustaMove.getGameInstance().setScreen(new HighScoreScreen());
             }
         });
         exitButton.addListener(new ChangeListener() {
@@ -173,19 +173,19 @@ public class MainMenuScreen extends AbstractMenuScreen {
         settingsButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new SettingsScreen());
+                BustaMove.getGameInstance().setScreen(new SettingsScreen());
             }
         });
         splitButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new TwoPlayerGameScreen(true, dynamicSettings));
+                BustaMove.getGameInstance().setScreen(new TwoPlayerGameScreen(true, dynamicSettings));
             }
         });
         shopButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 dispose();
-                game.setScreen(new ShopScreen(dynamicSettings, ownInstance));
+                BustaMove.getGameInstance().setScreen(new ShopScreen(dynamicSettings, ownInstance));
             }
         });
         

--- a/core/src/com/group66/game/screens/MainMenuScreen.java
+++ b/core/src/com/group66/game/screens/MainMenuScreen.java
@@ -2,20 +2,12 @@ package com.group66.game.screens;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.logging.MessageType;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
@@ -23,24 +15,26 @@ import com.group66.game.settings.DynamicSettings;
 /**
  * A Class for the MainMenuScreen of the game.
  */
-public class MainMenuScreen extends AbstractMenuScreen {
-    /** A place to store the game instance. */
-    private BustaMove game;
-
-    private Stage stage;
-    private Skin skin;
-    
+public class MainMenuScreen extends AbstractMenuScreen {  
     private static DynamicSettings dynamicSettings = new DynamicSettings();
     
     private Screen ownInstance;
+    
+    /** screen buttons */
+    private TextButton levelButton;
+    private TextButton randomButton;
+    private TextButton scoresButton;
+    private TextButton exitButton;
+    private TextButton settingsButton;
+    private TextButton splitButton;
+    private TextButton shopButton;
 
     /**
      * Instantiates a new main menu screen.
      */
     public MainMenuScreen() {
-        this.game = BustaMove.getGameInstance();
-        AssetLoader.load();
         ownInstance = this;
+        System.out.println("now start create main menu screen");
         createScreen();
         BustaMove.getGameInstance().log(MessageType.Info, "Loaded the main menu screen");
     }
@@ -55,57 +49,10 @@ public class MainMenuScreen extends AbstractMenuScreen {
     }
 
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-
-        skin = new Skin();
-
-        // Store the default libgdx font under the name "default".
-        BitmapFont bfont = new BitmapFont();
-        skin.add("default", bfont);
-
-        // Generate a 1x1 white texture and store it in the skin named "white".
-        Pixmap pixmap = new Pixmap(Config.BUTTON_WIDTH, Config.BUTTON_HEIGHT, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-
-        // Configure a TextButtonStyle and name it "default". Skin resources are
-        // stored by type, so this doesn't overwrite the font.
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
-        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-
-        //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
-        
-        TextButton levelButton = new TextButton("Career", textButtonStyle);
-        levelButton.setPosition(leftcol, yoffset);
-        
-        TextButton randomButton = new TextButton("Play: Random Level", textButtonStyle);
-        randomButton.setPosition(rightcol, yoffset);
-        
-        TextButton scoresButton = new TextButton("High scores", textButtonStyle);
-        scoresButton.setPosition(leftcol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
-        
-        TextButton splitButton = new TextButton("Play: Split screen", textButtonStyle);
-        splitButton.setPosition(rightcol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
-        
-        TextButton settingsButton = new TextButton("Settings", textButtonStyle);
-        settingsButton.setPosition(leftcol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-        
-        TextButton shopButton = new TextButton("Shop", textButtonStyle);
-        shopButton.setPosition(rightcol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-        
-        TextButton exitButton = new TextButton("Exit", textButtonStyle);
-        exitButton.setPosition(rightcol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-        
+        setupButtons();       
         stage.addActor(levelButton);
         stage.addActor(randomButton);
         stage.addActor(scoresButton);
@@ -113,6 +60,103 @@ public class MainMenuScreen extends AbstractMenuScreen {
         stage.addActor(settingsButton);
         stage.addActor(splitButton);
         stage.addActor(shopButton);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#render(float)
+     */
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        
+        /* Draw the background */
+        BustaMove.getGameInstance().batch.begin();
+        BustaMove.getGameInstance().batch.enableBlending();
+        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+                Gdx.graphics.getHeight());
+        BustaMove.getGameInstance().batch.end();
+        
+        stage.act();
+        stage.draw();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#show()
+     */
+    @Override
+    public void show() {
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#resize(int, int)
+     */
+    @Override
+    public void resize(int width, int height) {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#pause()
+     */
+    @Override
+    public void pause() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#resume()
+     */
+    @Override
+    public void resume() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#hide()
+     */
+    @Override
+    public void hide() {
+    }
+    
+    @Override
+    public void setupButtons() {
+        loadButtonMaterials();
+        //all magic numbers in this section are offsets values adjusted to get better looks
+        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+        
+        levelButton = new TextButton("Career", textButtonStyle);
+        levelButton.setPosition(leftcol, yoffset);
+        
+        randomButton = new TextButton("Play: Random Level", textButtonStyle);
+        randomButton.setPosition(rightcol, yoffset);
+        
+        scoresButton = new TextButton("High scores", textButtonStyle);
+        scoresButton.setPosition(leftcol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
+        
+        splitButton = new TextButton("Play: Split screen", textButtonStyle);
+        splitButton.setPosition(rightcol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
+        
+        settingsButton = new TextButton("Settings", textButtonStyle);
+        settingsButton.setPosition(leftcol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+        
+        shopButton = new TextButton("Shop", textButtonStyle);
+        shopButton.setPosition(rightcol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+        
+        exitButton = new TextButton("Exit", textButtonStyle);
+        exitButton.setPosition(rightcol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
         
         // Add a listener to the button. ChangeListener is fired when the
         // button's checked state changes, eg when clicked,
@@ -165,84 +209,6 @@ public class MainMenuScreen extends AbstractMenuScreen {
                 game.setScreen(new ShopScreen(dynamicSettings, ownInstance));
             }
         });
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#render(float)
-     */
-    @Override
-    public void render(float delta) {
-        Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         
-        /* Draw the background */
-        BustaMove.getGameInstance().batch.begin();
-        BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
-                Gdx.graphics.getHeight());
-        BustaMove.getGameInstance().batch.end();
-        
-        stage.act();
-        stage.draw();
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-        // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#hide()
-     */
-    @Override
-    public void hide() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#dispose()
-     */
-    @Override
-    public void dispose() {
-        stage.dispose();
-        skin.dispose();
     }
 }

--- a/core/src/com/group66/game/screens/MainMenuScreen.java
+++ b/core/src/com/group66/game/screens/MainMenuScreen.java
@@ -83,52 +83,6 @@ public class MainMenuScreen extends AbstractMenuScreen {
         stage.draw();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#hide()
-     */
-    @Override
-    public void hide() {
-    }
-    
     @Override
     public void setupButtons() {
         loadButtonMaterials();

--- a/core/src/com/group66/game/screens/MainMenuScreen.java
+++ b/core/src/com/group66/game/screens/MainMenuScreen.java
@@ -23,7 +23,7 @@ import com.group66.game.settings.DynamicSettings;
 /**
  * A Class for the MainMenuScreen of the game.
  */
-public class MainMenuScreen implements Screen {
+public class MainMenuScreen extends AbstractMenuScreen {
     /** A place to store the game instance. */
     private BustaMove game;
 
@@ -180,7 +180,7 @@ public class MainMenuScreen implements Screen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         BustaMove.getGameInstance().batch.end();
         

--- a/core/src/com/group66/game/screens/MainMenuScreen.java
+++ b/core/src/com/group66/game/screens/MainMenuScreen.java
@@ -12,22 +12,43 @@ import com.group66.game.logging.MessageType;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
 
+// TODO: Auto-generated Javadoc
 /**
  * A Class for the MainMenuScreen of the game.
  */
 public class MainMenuScreen extends AbstractMenuScreen {  
+    
+    /** The dynamic settings. */
     private static DynamicSettings dynamicSettings = new DynamicSettings();
     
+    /** The own instance. */
     private Screen ownInstance;
     
-    /** screen buttons */
+    /**  screen buttons. */
     private TextButton levelButton;
+    
+    /** The random button. */
     private TextButton randomButton;
+    
+    /** The scores button. */
     private TextButton scoresButton;
+    
+    /** The exit button. */
     private TextButton exitButton;
+    
+    /** The settings button. */
     private TextButton settingsButton;
+    
+    /** The split button. */
     private TextButton splitButton;
+    
+    /** The shop button. */
     private TextButton shopButton;
+    
+    /** variables used to calculate some drawing coordinates */
+    private int yoffset;
+    private int leftcol;
+    private int rightcol;
 
     /**
      * Instantiates a new main menu screen.
@@ -40,14 +61,17 @@ public class MainMenuScreen extends AbstractMenuScreen {
     }
     
     /**
-     * Instantiates a new main menu screen
-     * 
-     * @param dynamicSettings
+     * Instantiates a new main menu screen.
+     *
+     * @param dynamicSettings the dynamic settings
      */
     public MainMenuScreen(DynamicSettings dynamicSettings) {
         this();
     }
 
+    /**
+     * Creates the screen.
+     */
     private void createScreen() {
         loadRelatedGraphics();
         stage = new Stage();
@@ -62,10 +86,8 @@ public class MainMenuScreen extends AbstractMenuScreen {
         stage.addActor(shopButton);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#render(float)
+    /**
+     * renders the screen
      */
     @Override
     public void render(float delta) {
@@ -83,13 +105,16 @@ public class MainMenuScreen extends AbstractMenuScreen {
         stage.draw();
     }
 
+    /** 
+     * sets up screen buttons
+     */
     @Override
     public void setupButtons() {
         loadButtonMaterials();
         //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+        yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
         
         levelButton = new TextButton("Career", textButtonStyle);
         levelButton.setPosition(leftcol, yoffset);

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -40,7 +40,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         this.dynamicSettings = dynamicSettings;
         this.dynamicSettings.setRandomLevel(randomLevel);
         setup_keys();
-        AssetLoader.load();
+        loadRelatedGraphics();
         AudioManager.startMusic();
 
         if (!randomLevel) {
@@ -73,7 +73,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/
@@ -91,7 +91,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
 
         /* Draw the balls */
-        ballManager.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager.draw(this, BustaMove.getGameInstance().batch, delta);
 
         /* Check if balls need to move down */
         if (ballManager.getBallCount() >= Config.NBALLS_ROW_DOWN 

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -4,8 +4,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.GL20;
 import com.group66.game.BustaMove;
+import com.group66.game.cannon.BallAnimationLoader;
 import com.group66.game.cannon.BallManager;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.helpers.HighScoreManager;
 import com.group66.game.helpers.LevelLoader;
@@ -41,7 +41,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         this.dynamicSettings.setRandomLevel(randomLevel);
         setup_keys();
         loadRelatedGraphics();
-        AssetLoader.load();
+        BallAnimationLoader.load();
         AudioManager.startMusic();
 
         if (!randomLevel) {

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -92,7 +92,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
 
         /* Draw the balls */
-        ballManager.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager.draw(BustaMove.getGameInstance().batch, delta);
 
         /* Check if balls need to move down */
         if (ballManager.getBallCount() >= Config.NBALLS_ROW_DOWN 

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -92,7 +92,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
 
         /* Draw the balls */
-        ballManager.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager.draw(this, BustaMove.getGameInstance().batch, delta);
 
         /* Check if balls need to move down */
         if (ballManager.getBallCount() >= Config.NBALLS_ROW_DOWN 

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -74,7 +74,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(getPauseBackground(), 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/

--- a/core/src/com/group66/game/screens/OnePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/OnePlayerGameScreen.java
@@ -41,6 +41,7 @@ public class OnePlayerGameScreen extends AbstractGameScreen {
         this.dynamicSettings.setRandomLevel(randomLevel);
         setup_keys();
         loadRelatedGraphics();
+        AssetLoader.load();
         AudioManager.startMusic();
 
         if (!randomLevel) {

--- a/core/src/com/group66/game/screens/SettingsScreen.java
+++ b/core/src/com/group66/game/screens/SettingsScreen.java
@@ -2,21 +2,12 @@
 package com.group66.game.screens;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.DifficultyManager;
 import com.group66.game.logging.MessageType;
 import com.group66.game.settings.Config;
@@ -26,95 +17,31 @@ import com.group66.game.settings.Config;
  */
 public class SettingsScreen extends AbstractMenuScreen {
 
-    private Stage stage;
-    private Skin skin;
     private DifficultyManager difficultyManager = new DifficultyManager();
-
+    
+    /** sets up button */
+    private TextButton easyButton;
+    private TextButton mediumButton;
+    private TextButton hardButton;
+    private TextButton menuButton;
+    
     /**
      * Instantiates a new main menu screen.
      */
     public SettingsScreen() {
-        AssetLoader.load();
         createScreen();
         BustaMove.getGameInstance().log(MessageType.Info, "Loaded the settings screen");
     }
 
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
-        skin = new Skin();
-        Gdx.input.setInputProcessor(stage);
-        
-        // Store the default libgdx font under the name "default".
-        BitmapFont bfont = new BitmapFont();
-        skin.add("default", bfont);
-
-        // Generate a 1x1 white texture and store it in the skin named "white".
-        Pixmap pixmap = new Pixmap(Config.BUTTON_WIDTH, Config.BUTTON_HEIGHT, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-
-        // Configure a TextButtonStyle and name it "default". Skin resources are
-        // stored by type, so this doesn't overwrite the font.
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
-        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-
-        //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 75;
-        int centercol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2;
-        
-        TextButton easyButton = new TextButton("Easy", textButtonStyle);
-        easyButton.setPosition(centercol - Config.BUTTON_WIDTH - Config.BUTTON_SPACING, yoffset);
-        
-        TextButton mediumButton = new TextButton("Medium", textButtonStyle);
-        mediumButton.setPosition(centercol, yoffset);
-        
-        TextButton hardButton = new TextButton("Hard!", textButtonStyle);
-        hardButton.setPosition(centercol + Config.BUTTON_WIDTH + Config.BUTTON_SPACING, yoffset);
-
-        TextButton menuButton = new TextButton("Menu", textButtonStyle);
-        menuButton.setPosition(centercol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
-        
+        Gdx.input.setInputProcessor(stage);   
+        setupButtons();
         stage.addActor(easyButton);
         stage.addActor(mediumButton);
         stage.addActor(hardButton);
         stage.addActor(menuButton);
-
-        // Add a listener to the button. ChangeListener is fired when the
-        // button's checked state changes, eg when clicked,
-        // Button#setChecked() is called, via a key press, etc. If the
-        // event.cancel() is called, the checked state will be reverted.
-        // ClickListener could have been used, but would only fire when clicked.
-        // Also, canceling a ClickListener event won't
-        // revert the checked state.
-        easyButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                difficultyManager.setDifficulty("easy");
-                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to easy");
-            }
-        });
-        mediumButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                difficultyManager.setDifficulty("medium");
-                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to medium");
-            }
-        });
-        hardButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                difficultyManager.setDifficulty("hard");
-                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to hard");
-            }
-        });
-        menuButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                BustaMove.getGameInstance().setScreen(new MainMenuScreen());
-            }
-        });
     }
 
     /*
@@ -187,11 +114,56 @@ public class SettingsScreen extends AbstractMenuScreen {
 
     /*
      * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#dispose()
      */
     @Override
-    public void dispose() {
+    public void setupButtons() {
+        loadButtonMaterials();
+        //all magic numbers in this section are offsets values adjusted to get better looks
+        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 75;
+        int centercol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH) / 2;
+        
+        easyButton = new TextButton("Easy", textButtonStyle);
+        easyButton.setPosition(centercol - Config.BUTTON_WIDTH - Config.BUTTON_SPACING, yoffset);
+        
+        mediumButton = new TextButton("Medium", textButtonStyle);
+        mediumButton.setPosition(centercol, yoffset);
+        
+        hardButton = new TextButton("Hard!", textButtonStyle);
+        hardButton.setPosition(centercol + Config.BUTTON_WIDTH + Config.BUTTON_SPACING, yoffset);
+
+        menuButton = new TextButton("Menu", textButtonStyle);
+        menuButton.setPosition(centercol, yoffset - Config.BUTTON_HEIGHT - Config.BUTTON_SPACING);
+     
+        // Add a listener to the button. ChangeListener is fired when the
+        // button's checked state changes, eg when clicked,
+        // Button#setChecked() is called, via a key press, etc. If the
+        // event.cancel() is called, the checked state will be reverted.
+        // ClickListener could have been used, but would only fire when clicked.
+        // Also, canceling a ClickListener event won't
+        // revert the checked state.
+        easyButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                difficultyManager.setDifficulty("easy");
+                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to easy");
+            }
+        });
+        mediumButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                difficultyManager.setDifficulty("medium");
+                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to medium");
+            }
+        });
+        hardButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                difficultyManager.setDifficulty("hard");
+                BustaMove.getGameInstance().log(MessageType.Default, "Difficulty set to hard");
+            }
+        });
+        menuButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                BustaMove.getGameInstance().setScreen(new MainMenuScreen());
+            }
+        });
 
     }
 }

--- a/core/src/com/group66/game/screens/SettingsScreen.java
+++ b/core/src/com/group66/game/screens/SettingsScreen.java
@@ -24,7 +24,7 @@ import com.group66.game.settings.Config;
 /**
  * A Class for the SettingsScreen of the game.
  */
-public class SettingsScreen implements Screen {
+public class SettingsScreen extends AbstractMenuScreen {
 
     private Stage stage;
     private Skin skin;
@@ -130,7 +130,7 @@ public class SettingsScreen implements Screen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         BustaMove.getGameInstance().batch.end();
         

--- a/core/src/com/group66/game/screens/SettingsScreen.java
+++ b/core/src/com/group66/game/screens/SettingsScreen.java
@@ -67,53 +67,6 @@ public class SettingsScreen extends AbstractMenuScreen {
 
     /*
      * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-        // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#hide()
-     */
-    @Override
-    public void hide() {
-    }
-
-    /*
-     * (non-Javadoc)
      */
     @Override
     public void setupButtons() {

--- a/core/src/com/group66/game/screens/ShopScreen.java
+++ b/core/src/com/group66/game/screens/ShopScreen.java
@@ -180,46 +180,6 @@ public class ShopScreen extends AbstractMenuScreen {
         stage.draw();
     }
 
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-        
-    }
-
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-        
-
-    }
-
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-       
-    }
-
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-        
-    }
-
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#hide()
-     */
-    @Override
-    public void hide() {
-       
-    }
 
     /* (non-Javadoc)
      * @see com.badlogic.gdx.Screen#dispose()

--- a/core/src/com/group66/game/screens/ShopScreen.java
+++ b/core/src/com/group66/game/screens/ShopScreen.java
@@ -1,6 +1,5 @@
 package com.group66.game.screens;
 
-import java.lang.reflect.InvocationTargetException;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
@@ -8,15 +7,16 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.TextDrawer;
 import com.group66.game.logging.MessageType;
 import com.group66.game.settings.Config;
@@ -29,17 +29,27 @@ import com.group66.game.BustaMove;
 /**
  * A Class for the MainMenuScreen of the game.
  */
-public class ShopScreen implements Screen {
+public class ShopScreen extends AbstractMenuScreen {
 
     /** The dynamic settings. */
     private DynamicSettings dynamicSettings;
+   
+    /** New skin for this screen */
+    Skin skin;
+    
+    /**
+     * Textures for the override loadRelatedGraphics
+     */
+    /** ShopScreen background texture. */
+    private static Texture shopbgTexture;
 
-    /** The stage. */
-    private Stage stage;
+    /** ShopScreen background texture region. */
+    public static TextureRegion shopbg;
 
-    /** The skin. */
-    private Skin skin;
-
+    
+    /**
+     * screen buttons
+     */
     /** The buy score multiplier button. */
     private TextButton buyScoreMultiplierButton;
 
@@ -51,6 +61,9 @@ public class ShopScreen implements Screen {
 
     /** The buy extra life button. */
     private TextButton buyExtraLifeButton;
+    
+    /** Level button */
+    private TextButton levelButton;
 
     /** The buy score multiplier state machine. */
     private BuyScoreMultiplier buyScoreMultiplierStateMachine;
@@ -74,7 +87,6 @@ public class ShopScreen implements Screen {
     public ShopScreen(DynamicSettings dynamicSettings, Screen origin) {
         this.dynamicSettings = dynamicSettings;
         this.origin = origin;
-        AssetLoader.load();
         createScreen();
     }
 
@@ -82,116 +94,19 @@ public class ShopScreen implements Screen {
      * Creates the screen.
      */
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-        skin = new Skin();
-
-        // Store the default libgdx font under the name "default".
-        BitmapFont bfont = new BitmapFont();
-        skin.add("default", bfont);
 
         // Setup the text drawer to show the amount of coins
         textDrawer = new TextDrawer();
 
-        // Generate a 1x1 white texture and store it in the skin named "white".
-        Pixmap pixmap = new Pixmap((int) (Config.BUTTON_WIDTH * 2.5), Config.BUTTON_HEIGHT, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-
-        // Configure a TextButtonStyle and name it "default". Skin resources are
-        // stored by type, so this doesn't overwrite the font.
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
-        //textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-
-        //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH * 2.5) / 2);
-
-        TextButton levelButton = new TextButton("Back", textButtonStyle);
-        levelButton.setPosition(centercol, yoffset);
-
-        /* Buy Score Multiplier */
-        buyScoreMultiplierStateMachine = dynamicSettings.getBuyScoreMultiplierStateMachine();
-        buyScoreMultiplierButton = new TextButton("Buy: ", 
-                textButtonStyle);
-        buyScoreMultiplierButton.setPosition(centercol, yoffset - (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        /* Buy Special Bomb Chance */
-        buySpecialBombChanceStateMachine = dynamicSettings.getBuySpecialBombChanceStateMachine();
-        buyBombChanceButton = new TextButton("Buy: ", 
-                textButtonStyle);
-        buyBombChanceButton.setPosition(centercol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        /* Buy Ball Speed Multiplier */ 
-        buySpeedBoostStateMachine = dynamicSettings.getBuySpeedBoostStateMachine();
-        buySpeedMultiplierButton = new TextButton("Buy: ", 
-                textButtonStyle);
-        buySpeedMultiplierButton.setPosition(centercol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
-        /* Buy Extra Life */ 
-        buyExtraLifeButton = new TextButton("Buy: ", 
-                textButtonStyle);
-        buyExtraLifeButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
-
+        setupButtons();
         stage.addActor(levelButton);
         stage.addActor(buyScoreMultiplierButton);
         stage.addActor(buyBombChanceButton);
         stage.addActor(buySpeedMultiplierButton);
         stage.addActor(buyExtraLifeButton);
-
-        // Add a listener to the button. ChangeListener is fired when the
-        // button's checked state changes, eg when clicked,
-        // Button#setChecked() is called, via a key press, etc. If the
-        // event.cancel() is called, the checked state will be reverted.
-        // ClickListener could have been used, but would only fire when clicked.
-        // Also, canceling a ClickListener event won't
-        // revert the checked state.
-        levelButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                dispose();
-                try {
-                    BustaMove.getGameInstance().setScreen(origin.getClass()
-                            .getConstructor(DynamicSettings.class).newInstance(dynamicSettings));
-                } catch (Exception e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-            }
-        });
-
-        buyScoreMultiplierButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                buyScoreMultiplierStateMachine.buy(dynamicSettings);
-            }
-        });
-
-        buyBombChanceButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                buySpecialBombChanceStateMachine.buy(dynamicSettings);
-            }
-        });
-
-        buySpeedMultiplierButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                buySpeedBoostStateMachine.buy(dynamicSettings);
-            }
-        });
-
-        buyExtraLifeButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                if (!dynamicSettings.hasExtraLife() && dynamicSettings.getCurrency() >= Config.EXTRA_LIFE_COST) {
-                    dynamicSettings.setExtraLife(true);
-                    dynamicSettings.addCurrency(-1 * Config.EXTRA_LIFE_COST);
-                    BustaMove.getGameInstance().log(MessageType.Info, "Extra Life bought");
-                }
-            }
-        });
     }
 
     /**
@@ -255,7 +170,7 @@ public class ShopScreen implements Screen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.shopbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        BustaMove.getGameInstance().batch.draw(shopbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         textDrawer.draw(BustaMove.getGameInstance().batch, "You have " + dynamicSettings.getCurrency() + " Coins", 
                 Config.WIDTH / 2 - Config.LEVEL_WIDTH / 2 + Config.CURRENCY_X, Config.CURRENCY_Y);
@@ -310,7 +225,125 @@ public class ShopScreen implements Screen {
      * @see com.badlogic.gdx.Screen#dispose()
      */
     @Override
-    public void dispose() {
+    public void dispose() {     
+    }
+    
+    @Override
+    public void loadRelatedGraphics() {
+        //Creating the Store screen background
+        shopbgTexture = new Texture(Gdx.files.internal("shop.png"));
+        shopbgTexture.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
+        shopbg = new TextureRegion(shopbgTexture, 0, 0, 600, 880);    
+    }
+    
+    @Override
+    public void setupButtons() {
+        loadButtonMaterials();
+        
+        //all magic numbers in this section are offsets values adjusted to get better looks
+        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        int centercol = (int) ((Gdx.graphics.getWidth() - Config.BUTTON_WIDTH * 2.5) / 2);
+
+        /** level Button */
+        levelButton = new TextButton("Back", textButtonStyle);
+        levelButton.setPosition(centercol, yoffset);
+
+        /* Buy Score Multiplier */
+        buyScoreMultiplierStateMachine = dynamicSettings.getBuyScoreMultiplierStateMachine();
+        buyScoreMultiplierButton = new TextButton("Buy: ", 
+                textButtonStyle);
+        buyScoreMultiplierButton.setPosition(centercol, yoffset - (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        /* Buy Special Bomb Chance */
+        buySpecialBombChanceStateMachine = dynamicSettings.getBuySpecialBombChanceStateMachine();
+        buyBombChanceButton = new TextButton("Buy: ", 
+                textButtonStyle);
+        buyBombChanceButton.setPosition(centercol, yoffset - 2 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        /* Buy Ball Speed Multiplier */ 
+        buySpeedBoostStateMachine = dynamicSettings.getBuySpeedBoostStateMachine();
+        buySpeedMultiplierButton = new TextButton("Buy: ", 
+                textButtonStyle);
+        buySpeedMultiplierButton.setPosition(centercol, yoffset - 3 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        /* Buy Extra Life */ 
+        buyExtraLifeButton = new TextButton("Buy: ", 
+                textButtonStyle);
+        buyExtraLifeButton.setPosition(centercol, yoffset - 4 * (Config.BUTTON_HEIGHT + Config.BUTTON_SPACING));
+
+        // Add a listener to the button. ChangeListener is fired when the
+        // button's checked state changes, eg when clicked,
+        // Button#setChecked() is called, via a key press, etc. If the
+        // event.cancel() is called, the checked state will be reverted.
+        // ClickListener could have been used, but would only fire when clicked.
+        // Also, canceling a ClickListener event won't
+        // revert the checked state.
+        levelButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                dispose();
+                try {
+                    BustaMove.getGameInstance().setScreen(origin.getClass()
+                            .getConstructor(DynamicSettings.class).newInstance(dynamicSettings));
+                } catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        buyScoreMultiplierButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                buyScoreMultiplierStateMachine.buy(dynamicSettings);
+            }
+        });
+
+        buyBombChanceButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                buySpecialBombChanceStateMachine.buy(dynamicSettings);
+            }
+        });
+
+        buySpeedMultiplierButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                buySpeedBoostStateMachine.buy(dynamicSettings);
+            }
+        });
+
+        buyExtraLifeButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                if (!dynamicSettings.hasExtraLife() && dynamicSettings.getCurrency() >= Config.EXTRA_LIFE_COST) {
+                    dynamicSettings.setExtraLife(true);
+                    dynamicSettings.addCurrency(-1 * Config.EXTRA_LIFE_COST);
+                    BustaMove.getGameInstance().log(MessageType.Info, "Extra Life bought");
+                }
+            }
+        });     
+    }
+    
+    @Override
+    public void loadButtonMaterials() {
+        skin = new Skin();
+        
+        // Store the default libgdx font under the name "default".
+        BitmapFont bfont = new BitmapFont();
+        skin.add("default", bfont);
+        
+        // Generate a 1x1 white texture and store it in the skin named "white".
+        Pixmap pixmap = new Pixmap((int) (Config.BUTTON_WIDTH * 2.5), Config.BUTTON_HEIGHT, Format.RGBA8888);
+        pixmap.setColor(Color.WHITE);
+        pixmap.fill();
+        skin.add("white", new Texture(pixmap));
+
+        // Configure a TextButtonStyle and name it "default". Skin resources are
+        // stored by type, so this doesn't overwrite the font.
+        textButtonStyle = new TextButtonStyle();
+        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
+        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
+        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
+        textButtonStyle.font = skin.getFont("default");
+        skin.add("default", textButtonStyle);
+        
         
     }
+    
 }

--- a/core/src/com/group66/game/screens/ShopScreen.java
+++ b/core/src/com/group66/game/screens/ShopScreen.java
@@ -33,10 +33,6 @@ public class ShopScreen extends AbstractMenuScreen {
 
     /** The dynamic settings. */
     private DynamicSettings dynamicSettings;
-   
-    /** New skin for this screen */
-    private Stage stage;
-    private Skin skin;
     
     /**
      * Textures for the override loadRelatedGraphics
@@ -294,9 +290,7 @@ public class ShopScreen extends AbstractMenuScreen {
         textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
         textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
         textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-        
-        
+        skin.add("default", textButtonStyle);      
     }
-    
+
 }

--- a/core/src/com/group66/game/screens/ShopScreen.java
+++ b/core/src/com/group66/game/screens/ShopScreen.java
@@ -35,16 +35,17 @@ public class ShopScreen extends AbstractMenuScreen {
     private DynamicSettings dynamicSettings;
    
     /** New skin for this screen */
-    Skin skin;
+    private Stage stage;
+    private Skin skin;
     
     /**
      * Textures for the override loadRelatedGraphics
      */
     /** ShopScreen background texture. */
-    private static Texture shopbgTexture;
+    private Texture shopbgTexture;
 
     /** ShopScreen background texture region. */
-    public static TextureRegion shopbg;
+    private TextureRegion shopbg;
 
     
     /**
@@ -178,14 +179,6 @@ public class ShopScreen extends AbstractMenuScreen {
 
         stage.act();
         stage.draw();
-    }
-
-
-    /* (non-Javadoc)
-     * @see com.badlogic.gdx.Screen#dispose()
-     */
-    @Override
-    public void dispose() {     
     }
     
     @Override

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -73,44 +73,6 @@ public class StartScreen extends AbstractMenuScreen {
     /*
      * (non-Javadoc)
      * 
-     * @see com.badlogic.gdx.Screen#show()
-     */
-    @Override
-    public void show() {
-
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resize(int, int)
-     */
-    @Override
-    public void resize(int width, int height) {
-       
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#pause()
-     */
-    @Override
-    public void pause() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#resume()
-     */
-    @Override
-    public void resume() {
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
      * @see com.badlogic.gdx.Screen#hide()
      */
     @Override

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -22,7 +22,7 @@ import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
 
 /**
- * A Class for the MainMenuScreen of the game.
+ * A Class for the StarScreen of the game.
  */
 public class StartScreen implements Screen {
     /** A place to store the game instance. */
@@ -35,7 +35,7 @@ public class StartScreen implements Screen {
     private static DynamicSettings dynamicSettings = new DynamicSettings();
 
     /**
-     * Instantiates a new main menu screen.
+     * Instantiates a new start screen.
      */
     public StartScreen() {
         this.game = BustaMove.getGameInstance();
@@ -57,9 +57,7 @@ public class StartScreen implements Screen {
     private void createScreen() {
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-
         skin = new Skin();
-
 
         // Store the default libgdx font under the name "default".
         BitmapFont bfont = new BitmapFont();
@@ -91,8 +89,6 @@ public class StartScreen implements Screen {
 
         TextButton startButton = new TextButton("Start game!", textButtonStyle);
         startButton.setPosition(rightcol, yoffset);
-
-
 
         stage.addActor(setName);
         stage.addActor(startButton);

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -1,18 +1,10 @@
 package com.group66.game.screens;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
 import com.group66.game.helpers.AssetLoader;

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -24,24 +24,20 @@ import com.group66.game.settings.DynamicSettings;
 /**
  * A Class for the StarScreen of the game.
  */
-public class StartScreen implements Screen {
-    /** A place to store the game instance. */
-    private BustaMove game;
-
-    private Stage stage;
-    
-    private Skin skin;
+public class StartScreen extends AbstractMenuScreen {
 
     private static DynamicSettings dynamicSettings = new DynamicSettings();
-
+    
+    /** screen buttons */
+    private TextButton setName;
+    private TextButton startButton;
+    
     /**
      * Instantiates a new start screen.
      */
     public StartScreen() {
         this.game = BustaMove.getGameInstance();
-        AssetLoader.load();
         BustaMove.getGameInstance().getHighScoreManager().loadData();
-       
         createScreen();
         BustaMove.getGameInstance().log(MessageType.Info, "Loaded the startup menu screen");
     }
@@ -55,68 +51,13 @@ public class StartScreen implements Screen {
     }
 
     private void createScreen() {
+        loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-        skin = new Skin();
-
-        // Store the default libgdx font under the name "default".
-        BitmapFont bfont = new BitmapFont();
-        skin.add("default", bfont);
-
-        // Generate a 1x1 white texture and store it in the skin named "white".
-        Pixmap pixmap = new Pixmap(Config.BUTTON_WIDTH, Config.BUTTON_HEIGHT, Format.RGBA8888);
-        pixmap.setColor(Color.WHITE);
-        pixmap.fill();
-        skin.add("white", new Texture(pixmap));
-
-        // Configure a TextButtonStyle and name it "default". Skin resources are
-        // stored by type, so this doesn't overwrite the font.
-        TextButtonStyle textButtonStyle = new TextButtonStyle();
-        textButtonStyle.up = skin.newDrawable("white", Color.GRAY);
-        textButtonStyle.down = skin.newDrawable("white", Color.DARK_GRAY);
-        textButtonStyle.checked = skin.newDrawable("white", Color.BLUE);
-        textButtonStyle.over = skin.newDrawable("white", Color.LIGHT_GRAY);
-        textButtonStyle.font = skin.getFont("default");
-        skin.add("default", textButtonStyle);
-
-        //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
-
-        TextButton setName = new TextButton("Enter name", textButtonStyle);
-        setName.setPosition(leftcol, yoffset);
-
-        TextButton startButton = new TextButton("Start game!", textButtonStyle);
-        startButton.setPosition(rightcol, yoffset);
-
+        loadButtonMaterials();
+        setupButtons();
         stage.addActor(setName);
         stage.addActor(startButton);
-
-
-        // Add a listener to the button. ChangeListener is fired when the
-        // button's checked state changes, eg when clicked,
-        // Button#setChecked() is called, via a key press, etc. If the
-        // event.cancel() is called, the checked state will be reverted.
-        // ClickListener could have been used, but would only fire when clicked.
-        // Also, canceling a ClickListener event won't
-        // revert the checked state.
-        setName.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                NameInputListener listener = new NameInputListener(dynamicSettings);
-                Gdx.input.getTextInput(listener, "Enter your name", "", "");
-            }
-        });
-        startButton.addListener(new ChangeListener() {
-            public void changed(ChangeEvent event, Actor actor) {
-                if (!dynamicSettings.getName().equals("")) {
-                    AssetLoader.profileManager.readData(dynamicSettings.getName(), dynamicSettings);
-                    dispose();
-                    game.setScreen(new MainMenuScreen());
-                }
-            }
-        });
-
     }
 
     /*
@@ -132,7 +73,7 @@ public class StartScreen implements Screen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+        BustaMove.getGameInstance().batch.draw(mmbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());
         BustaMove.getGameInstance().batch.end();
         stage.act();
@@ -196,4 +137,40 @@ public class StartScreen implements Screen {
         stage.dispose();
         skin.dispose();
     }
+    
+    public void setupButtons() {
+        loadButtonMaterials();
+        //all magic numbers in this section are offsets values adjusted to get better looks
+        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+
+        setName = new TextButton("Enter name", textButtonStyle);
+        setName.setPosition(leftcol, yoffset);
+        startButton = new TextButton("Start game!", textButtonStyle);
+        startButton.setPosition(rightcol, yoffset);
+        // Add a listener to the button. ChangeListener is fired when the
+        // button's checked state changes, eg when clicked,
+        // Button#setChecked() is called, via a key press, etc. If the
+        // event.cancel() is called, the checked state will be reverted.
+        // ClickListener could have been used, but would only fire when clicked.
+        // Also, canceling a ClickListener event won't
+        // revert the checked state.
+        setName.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                NameInputListener listener = new NameInputListener(dynamicSettings);
+                Gdx.input.getTextInput(listener, "Enter your name", "", "");
+            }
+        });
+        startButton.addListener(new ChangeListener() {
+            public void changed(ChangeEvent event, Actor actor) {
+                if (!dynamicSettings.getName().equals("")) {
+                    AssetLoader.profileManager.readData(dynamicSettings.getName(), dynamicSettings);
+                    dispose();
+                    game.setScreen(new MainMenuScreen());
+                }
+            }
+        });    
+    }
+
 }

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -118,7 +118,7 @@ public class StartScreen extends AbstractMenuScreen {
                 if (!dynamicSettings.getName().equals("")) {
                     BallAnimationLoader.profileManager.readData(dynamicSettings.getName(), dynamicSettings);
                     dispose();
-                    game.setScreen(new MainMenuScreen());
+                    BustaMove.getGameInstance().setScreen(new MainMenuScreen());
                 }
             }
         });    

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -24,6 +24,11 @@ public class StartScreen extends AbstractMenuScreen {
     private TextButton setName;
     private TextButton startButton;
     
+    /** variables used to calculate some drawing coordinates */
+    private int yoffset;
+    private int leftcol;
+    private int rightcol;
+    
     /**
      * Instantiates a new start screen.
      */
@@ -79,12 +84,15 @@ public class StartScreen extends AbstractMenuScreen {
     public void hide() {
     }
     
+    /**
+     * sets up buttons
+     */
     public void setupButtons() {
         loadButtonMaterials();
         //all magic numbers in this section are offsets values adjusted to get better looks
-        int yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
-        int leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
-        int rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
+        yoffset = Gdx.graphics.getHeight() / 2 + Config.BUTTON_HEIGHT + Config.BUTTON_SPACING - 50;
+        leftcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH - 250) / 2;
+        rightcol = (Gdx.graphics.getWidth() - Config.BUTTON_WIDTH + 250) / 2;
 
         setName = new TextButton("Enter name", textButtonStyle);
         setName.setPosition(leftcol, yoffset);

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
+import com.group66.game.cannon.BallAnimationLoader;
 import com.group66.game.input.NameInputListener;
 import com.group66.game.logging.MessageType;
 import com.group66.game.settings.Config;
@@ -108,7 +108,7 @@ public class StartScreen extends AbstractMenuScreen {
         startButton.addListener(new ChangeListener() {
             public void changed(ChangeEvent event, Actor actor) {
                 if (!dynamicSettings.getName().equals("")) {
-                    AssetLoader.profileManager.readData(dynamicSettings.getName(), dynamicSettings);
+                    BallAnimationLoader.profileManager.readData(dynamicSettings.getName(), dynamicSettings);
                     dispose();
                     game.setScreen(new MainMenuScreen());
                 }

--- a/core/src/com/group66/game/screens/StartScreen.java
+++ b/core/src/com/group66/game/screens/StartScreen.java
@@ -36,7 +36,6 @@ public class StartScreen extends AbstractMenuScreen {
      * Instantiates a new start screen.
      */
     public StartScreen() {
-        this.game = BustaMove.getGameInstance();
         BustaMove.getGameInstance().getHighScoreManager().loadData();
         createScreen();
         BustaMove.getGameInstance().log(MessageType.Info, "Loaded the startup menu screen");
@@ -54,7 +53,6 @@ public class StartScreen extends AbstractMenuScreen {
         loadRelatedGraphics();
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
-        loadButtonMaterials();
         setupButtons();
         stage.addActor(setName);
         stage.addActor(startButton);
@@ -97,7 +95,7 @@ public class StartScreen extends AbstractMenuScreen {
      */
     @Override
     public void resize(int width, int height) {
-        // game.batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+       
     }
 
     /*
@@ -126,17 +124,6 @@ public class StartScreen extends AbstractMenuScreen {
     @Override
     public void hide() {
     }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.badlogic.gdx.Screen#dispose()
-     */
-    @Override
-    public void dispose() {
-        stage.dispose();
-        skin.dispose();
-    }
     
     public void setupButtons() {
         loadButtonMaterials();
@@ -147,8 +134,10 @@ public class StartScreen extends AbstractMenuScreen {
 
         setName = new TextButton("Enter name", textButtonStyle);
         setName.setPosition(leftcol, yoffset);
+        
         startButton = new TextButton("Start game!", textButtonStyle);
         startButton.setPosition(rightcol, yoffset);
+        
         // Add a listener to the button. ChangeListener is fired when the
         // button's checked state changes, eg when clicked,
         // Button#setChecked() is called, via a key press, etc. If the

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -81,7 +81,7 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(getPauseBackground(), 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -103,9 +103,9 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager3.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager3.draw(this, BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver() || ballManager3.isGameOver()) {

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -43,6 +43,7 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         ballManager2 = new BallManager(2, dynamicSettings);
         ballManager3 = new BallManager(1, dynamicSettings);
         setup_keys();
+        AssetLoader.load();
         loadRelatedGraphics();
         AudioManager.startMusic();
 

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -4,8 +4,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.GL20;
 import com.group66.game.BustaMove;
+import com.group66.game.cannon.BallAnimationLoader;
 import com.group66.game.cannon.BallManager;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.helpers.HighScoreManager;
 import com.group66.game.helpers.LevelLoader;
@@ -43,7 +43,7 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         ballManager2 = new BallManager(2, dynamicSettings);
         ballManager3 = new BallManager(1, dynamicSettings);
         setup_keys();
-        AssetLoader.load();
+        BallAnimationLoader.load();
         loadRelatedGraphics();
         AudioManager.startMusic();
 

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -43,7 +43,7 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         ballManager2 = new BallManager(2, dynamicSettings);
         ballManager3 = new BallManager(1, dynamicSettings);
         setup_keys();
-        AssetLoader.load();
+        loadRelatedGraphics();
         AudioManager.startMusic();
 
         if (!randomLevel) {
@@ -80,7 +80,7 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/
@@ -102,9 +102,9 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager3.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager3.draw(this, BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver() || ballManager3.isGameOver()) {

--- a/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/ThreePlayerGameScreen.java
@@ -103,9 +103,9 @@ public class ThreePlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
-        ballManager3.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager3.draw(BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver() || ballManager3.isGameOver()) {

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -97,8 +97,8 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver()) {

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -77,7 +77,7 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(getPauseBackground(), 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -97,8 +97,8 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver()) {

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -41,6 +41,7 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         ballManager1 = new BallManager(0, dynamicSettings);
         ballManager2 = new BallManager(2, dynamicSettings);
         setup_keys();
+        AssetLoader.load();
         loadRelatedGraphics();
         AudioManager.startMusic();
 

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -4,8 +4,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.GL20;
 import com.group66.game.BustaMove;
+import com.group66.game.cannon.BallAnimationLoader;
 import com.group66.game.cannon.BallManager;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.AudioManager;
 import com.group66.game.helpers.HighScoreManager;
 import com.group66.game.helpers.LevelLoader;
@@ -41,7 +41,7 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         ballManager1 = new BallManager(0, dynamicSettings);
         ballManager2 = new BallManager(2, dynamicSettings);
         setup_keys();
-        AssetLoader.load();
+        BallAnimationLoader.load();
         loadRelatedGraphics();
         AudioManager.startMusic();
 

--- a/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
+++ b/core/src/com/group66/game/screens/TwoPlayerGameScreen.java
@@ -41,7 +41,7 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         ballManager1 = new BallManager(0, dynamicSettings);
         ballManager2 = new BallManager(2, dynamicSettings);
         setup_keys();
-        AssetLoader.load();
+        loadRelatedGraphics();
         AudioManager.startMusic();
 
         if (!randomLevel) {
@@ -76,7 +76,7 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         /* Don't update and render when the game is paused */
         if (gameState == GameState.PAUSED) {
             BustaMove.getGameInstance().batch.begin();
-            BustaMove.getGameInstance().batch.draw(AssetLoader.pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
+            BustaMove.getGameInstance().batch.draw(pausebg, 0, 0, Config.WIDTH, Config.HEIGHT);
             BustaMove.getGameInstance().batch.end();
             
             /* Update the balls without letting them move*/
@@ -96,8 +96,8 @@ public class TwoPlayerGameScreen extends AbstractGameScreen {
         BustaMove.getGameInstance().batch.enableBlending();
         
         /* Draw the balls */
-        ballManager1.draw(BustaMove.getGameInstance().batch, delta);
-        ballManager2.draw(BustaMove.getGameInstance().batch, delta);
+        ballManager1.draw(this, BustaMove.getGameInstance().batch, delta);
+        ballManager2.draw(this, BustaMove.getGameInstance().batch, delta);
         
         /* Check if game-over condition is reached */
         if (ballManager1.isGameOver() || ballManager2.isGameOver()) {

--- a/core/src/com/group66/game/screens/YouLoseScreenCareer.java
+++ b/core/src/com/group66/game/screens/YouLoseScreenCareer.java
@@ -17,7 +17,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.TextDrawer;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
@@ -39,7 +38,7 @@ public class YouLoseScreenCareer extends AbstractYouLoseScreen {
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
         Skin skin = new Skin();
-
+        loadRelatedGraphics();
 
         // Store the default libgdx font under the name "default".
         BitmapFont bfont = new BitmapFont();
@@ -118,7 +117,7 @@ public class YouLoseScreenCareer extends AbstractYouLoseScreen {
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        BustaMove.getGameInstance().batch.draw(AssetLoader.youlosebg, 
+        BustaMove.getGameInstance().batch.draw(youlosebg, 
                 Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH, Gdx.graphics.getHeight());
         
         if (!dynamicSettings.hasExtraLife()) { 

--- a/core/src/com/group66/game/screens/YouLoseScreenRandom.java
+++ b/core/src/com/group66/game/screens/YouLoseScreenRandom.java
@@ -37,7 +37,7 @@ public class YouLoseScreenRandom extends AbstractYouLoseScreen {
         stage = new Stage();
         Gdx.input.setInputProcessor(stage);
         skin = new Skin();
-
+        loadRelatedGraphics();
         // Store the default libgdx font under the name "default".
         BitmapFont bfont = new BitmapFont();
         skin.add("default", bfont);

--- a/core/src/com/group66/game/screens/YouWinScreenCareer.java
+++ b/core/src/com/group66/game/screens/YouWinScreenCareer.java
@@ -14,7 +14,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.group66.game.BustaMove;
-import com.group66.game.helpers.AssetLoader;
 import com.group66.game.helpers.TextDrawer;
 import com.group66.game.settings.Config;
 import com.group66.game.settings.DynamicSettings;
@@ -113,13 +112,14 @@ public class YouWinScreenCareer extends AbstractYouWinScreen {
     public void render(float delta) {
         Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
+        loadRelatedGraphics();
+        
         /* Draw the background */
         BustaMove.getGameInstance().batch.begin();
         BustaMove.getGameInstance().batch.enableBlending();
-        TextureRegion bg = AssetLoader.youwinbg;
+        TextureRegion bg = youwinbg;
         if (dynamicSettings.getLevelCleared() == Config.NUMBER_OF_LEVELS ) {
-            bg = AssetLoader.youwinAllbg;
+            bg = youwinAllbg;
         }
         BustaMove.getGameInstance().batch.draw(bg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
                 Gdx.graphics.getHeight());

--- a/core/src/com/group66/game/screens/YouWinScreenRandom.java
+++ b/core/src/com/group66/game/screens/YouWinScreenRandom.java
@@ -4,6 +4,7 @@
 package com.group66.game.screens;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
@@ -65,6 +66,28 @@ public class YouWinScreenRandom extends AbstractYouWinScreen {
                 Gdx.app.exit();
             }
         });
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.badlogic.gdx.Screen#render(float)
+     */
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0.2f, 0.2f, 0.3f, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        loadRelatedGraphics();
+        
+        /* Draw the background */
+        BustaMove.getGameInstance().batch.begin();
+        BustaMove.getGameInstance().batch.enableBlending();
+        BustaMove.getGameInstance().batch.draw(youwinbg, Config.SINGLE_PLAYER_OFFSET, 0, Config.LEVEL_WIDTH,
+                Gdx.graphics.getHeight());
+        BustaMove.getGameInstance().batch.end();
+
+        stage.act();
+        stage.draw();
     }
 
 }

--- a/core/src/com/group66/game/settings/DynamicSettings.java
+++ b/core/src/com/group66/game/settings/DynamicSettings.java
@@ -2,7 +2,7 @@ package com.group66.game.settings;
 
 import java.util.ArrayList;
 
-import com.group66.game.helpers.AssetLoader;
+import com.group66.game.cannon.BallAnimationLoader;
 import com.group66.game.shop.BuyScoreMultiplier;
 import com.group66.game.shop.BuySpecialBombChance;
 import com.group66.game.shop.BuySpeedBoost;
@@ -94,7 +94,7 @@ public class DynamicSettings {
      */
     public void setName(String name) {
         this.name = name;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -113,7 +113,7 @@ public class DynamicSettings {
      */
     public void setCurrency(int currency) {
         this.currency = currency;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -123,7 +123,7 @@ public class DynamicSettings {
      */
     public void addCurrency(int dcurrency) {
         this.currency += dcurrency;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -143,7 +143,7 @@ public class DynamicSettings {
      */
     public void setScoreMultiplier(double scoreMultiplier) {
         this.scoreMultiplier = scoreMultiplier;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -162,7 +162,7 @@ public class DynamicSettings {
      */
     public void setSpecialBombChanceMultiplier(double specialBombChance) {
         this.specialBombChanceMultiplier = specialBombChance;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
 
@@ -182,7 +182,7 @@ public class DynamicSettings {
      */
     public void setBallSpeedMultiplier(double ballSpeedMultiplier) {
         this.ballSpeedMultiplier = ballSpeedMultiplier;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -201,7 +201,7 @@ public class DynamicSettings {
      */
     public void setExtraLife(boolean extraLife) {
         this.extraLife = extraLife;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**
@@ -248,7 +248,7 @@ public class DynamicSettings {
     public void setCurrentLevel(int currentLevel) {
         if (currentLevel <= Config.NUMBER_OF_LEVELS) {
             this.currentLevel = currentLevel;
-            AssetLoader.profileManager.writeData(this);
+            BallAnimationLoader.profileManager.writeData(this);
         }
     } 
 
@@ -265,7 +265,7 @@ public class DynamicSettings {
     public void setLevelCleared(int levelCleared) {
         if (levelCleared > this.levelCleared) {
             this.levelCleared = levelCleared;
-            AssetLoader.profileManager.writeData(this);
+            BallAnimationLoader.profileManager.writeData(this);
         }
     }
 
@@ -284,7 +284,7 @@ public class DynamicSettings {
      */
     public void setRandomLevel(boolean randomLevel) {
         this.randomLevel = randomLevel;
-        AssetLoader.profileManager.writeData(this);
+        BallAnimationLoader.profileManager.writeData(this);
     }
 
     /**


### PR DESCRIPTION
-- Fixed 3 flawed classes:
1) AssetLoader is no longer a Data Class. Its functionality was distributed by moving sprites to their respective classes. After that, all sprites related to balls animation were left. AssetLoader was renamed as BallAnimationLoader, and was moved to the cannon package.
2) The two External duplications that existed in the MainMenuScreen and StartScreen were fixed. This was by the means of refactoring the screens.

--Refactored normal screens (is necessary for AssetLoader splitting)
All 6 normal screens (mainmenu, start, settings, career, shop, and highscore) now extend the new AbstractMenuScreen class. This helped was required for a better split for the AssetLoader. It improved code decoupling and cohesion, minimized the number of  class dependencies, and fixed the 2 duplication flaws that exist in the MainMenu and StartScreen.

-- This branch was tested heavily. However, please be sure to check every possible action related to screens just in case I've missed one that's buggy.